### PR TITLE
Improve auth flows with refresh and logout

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/config/SecurityConfiguration.java
+++ b/src/main/java/com/meztlitech/agrobitacora/config/SecurityConfiguration.java
@@ -13,6 +13,7 @@ import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,6 +32,7 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 @Log4j2
 public class SecurityConfiguration {

--- a/src/main/java/com/meztlitech/agrobitacora/controller/AuthenticationController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/AuthenticationController.java
@@ -41,6 +41,16 @@ public class AuthenticationController {
         return ResponseEntity.ok(authenticationService.verify(token));
     }
 
+    @PostMapping("/refresh")
+    public ResponseEntity<UserResponse> refreshToken(@RequestHeader(value = "Authorization") final String token) {
+        return ResponseEntity.ok(authenticationService.refreshToken(token));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.ok().build();
+    }
+
     @PutMapping("/changePassword/{id}")
     public ResponseEntity<ActionStatusResponse> update(@PathVariable(name = "id") final long id,
                                                        @RequestBody UserDto userDto) {

--- a/src/main/java/com/meztlitech/agrobitacora/entity/UserEntity.java
+++ b/src/main/java/com/meztlitech/agrobitacora/entity/UserEntity.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.apache.commons.lang3.StringUtils;
+import java.util.Objects;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -48,8 +50,8 @@ public class UserEntity implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<SimpleGrantedAuthority> authorities = new HashSet<>();
-        if (this.id.equals(0L)) {
-            authorities.add(new SimpleGrantedAuthority("admin"));
+        if (Objects.nonNull(this.role) && StringUtils.isNotBlank(this.role.getName())) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + this.role.getName().toUpperCase()));
         }
         return authorities;
     }

--- a/src/main/java/com/meztlitech/agrobitacora/service/AuthenticationService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/AuthenticationService.java
@@ -133,4 +133,21 @@ public class AuthenticationService {
 
         return userDto;
     }
+
+    public UserResponse refreshToken(String token) {
+        Claims claims = jwtService.decodeToken(token);
+        String email = claims.get("email").toString();
+        UserEntity user = userRepository.findByUserName(email)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid token"));
+        String newToken = jwtService.generateToken(user, user.getId());
+
+        UserResponse userDto = new UserResponse();
+        userDto.setEmail(user.getUsername());
+        userDto.setId(user.getId());
+        userDto.setFullName(user.getName());
+        userDto.setRole(user.getRole());
+        userDto.setToken(newToken);
+
+        return userDto;
+    }
 }

--- a/src/main/resources/templates/fragments/scripts.html
+++ b/src/main/resources/templates/fragments/scripts.html
@@ -32,6 +32,14 @@
                     }
                 });
             });
+            const btnLogout = document.getElementById('logout');
+            if (btnLogout) {
+                btnLogout.addEventListener('click', async () => {
+                    await fetch('/auth/logout', { method: 'POST', headers: { 'Authorization': 'Bearer ' + localStorage.getItem('token') }});
+                    localStorage.removeItem('token');
+                    location.href = '/auth';
+                });
+            }
         });
     </script>
 </th:block>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -18,6 +18,7 @@
     <a class="list-group-item list-group-item-action" th:href="@{/nutrition}">Nutrition</a>
     <a class="list-group-item list-group-item-action" th:href="@{/production}">Production</a>
   </div>
+  <button id="logout" class="btn btn-danger mt-3">Cerrar sesión</button>
 </div>
 <div th:replace="fragments/scripts :: scripts"></div>
 </body>


### PR DESCRIPTION
## Summary
- enable method security in SecurityConfiguration
- expose refresh token and logout endpoints
- provide logout button in UI and handle logout in scripts
- add new refreshToken logic in AuthenticationService
- map roles to proper authorities

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848c8a5d7b88323823f0e8010ae663d