### PR TITLE
Add basic admin module

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/controller/AdminController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/AdminController.java
@@ -1,0 +1,85 @@
+package com.meztlitech.agrobitacora.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meztlitech.agrobitacora.dto.CropDto;
+import com.meztlitech.agrobitacora.dto.UserDto;
+import com.meztlitech.agrobitacora.dto.UserResponse;
+import com.meztlitech.agrobitacora.dto.ActionStatusResponse;
+import com.meztlitech.agrobitacora.dto.admin.AdminCountsDto;
+import com.meztlitech.agrobitacora.entity.CropEntity;
+import com.meztlitech.agrobitacora.entity.RoleEntity;
+import com.meztlitech.agrobitacora.entity.UserEntity;
+import com.meztlitech.agrobitacora.service.AdminService;
+import com.meztlitech.agrobitacora.service.JwtService;
+import io.jsonwebtoken.Claims;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@Log4j2
+public class AdminController {
+
+    private final AdminService adminService;
+    private final JwtService jwtService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String ROLE_ADMIN = "Administrador";
+
+    private void validateAdmin(String token) {
+        Claims claims = jwtService.decodeToken(token);
+        RoleEntity role = objectMapper.convertValue(claims.get("role"), RoleEntity.class);
+        if (!ROLE_ADMIN.equals(role.getName())) {
+            throw new HttpServerErrorException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+    }
+
+    @PostMapping("/users/{userId}/crops")
+    public ResponseEntity<CropEntity> createCrop(@PathVariable Long userId,
+                                                 @Valid @RequestBody CropDto cropDto,
+                                                 @RequestHeader(value = "Authorization") String token) {
+        validateAdmin(token);
+        return ResponseEntity.ok(adminService.createCropForUser(userId, cropDto));
+    }
+
+    @GetMapping("/users")
+    public ResponseEntity<List<UserEntity>> users(@RequestHeader(value = "Authorization") String token) {
+        validateAdmin(token);
+        return ResponseEntity.ok(adminService.getUsers());
+    }
+
+    @PostMapping("/users")
+    public ResponseEntity<UserResponse> createUser(@Valid @RequestBody UserDto userDto,
+                                                   @RequestHeader(value = "Authorization") String token) {
+        validateAdmin(token);
+        return ResponseEntity.ok(adminService.createUser(userDto));
+    }
+
+    @PutMapping("/users/{id}/password")
+    public ResponseEntity<ActionStatusResponse> changePassword(@PathVariable Long id,
+                                                               @RequestBody UserDto userDto,
+                                                               @RequestHeader(value = "Authorization") String token) {
+        validateAdmin(token);
+        return ResponseEntity.ok(adminService.changePassword(id, userDto));
+    }
+
+    @DeleteMapping("/users/{id}")
+    public ResponseEntity<ActionStatusResponse> deleteUser(@PathVariable Long id,
+                                                           @RequestHeader(value = "Authorization") String token) {
+        validateAdmin(token);
+        return ResponseEntity.ok(adminService.deleteUser(id));
+    }
+
+    @GetMapping("/counts")
+    public ResponseEntity<AdminCountsDto> counts(@RequestHeader(value = "Authorization") String token) {
+        validateAdmin(token);
+        return ResponseEntity.ok(adminService.getCounts());
+    }
+}

--- a/src/main/java/com/meztlitech/agrobitacora/dto/admin/AdminCountsDto.java
+++ b/src/main/java/com/meztlitech/agrobitacora/dto/admin/AdminCountsDto.java
@@ -1,0 +1,9 @@
+package com.meztlitech.agrobitacora.dto.admin;
+
+import lombok.Data;
+
+@Data
+public class AdminCountsDto {
+    private long users;
+    private long crops;
+}

--- a/src/main/java/com/meztlitech/agrobitacora/service/AdminService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/AdminService.java
@@ -1,0 +1,63 @@
+package com.meztlitech.agrobitacora.service;
+
+import com.meztlitech.agrobitacora.dto.UserDto;
+import com.meztlitech.agrobitacora.dto.UserResponse;
+import com.meztlitech.agrobitacora.dto.admin.AdminCountsDto;
+import com.meztlitech.agrobitacora.dto.ActionStatusResponse;
+import com.meztlitech.agrobitacora.dto.CropDto;
+import com.meztlitech.agrobitacora.entity.CropEntity;
+import com.meztlitech.agrobitacora.entity.UserEntity;
+import com.meztlitech.agrobitacora.repository.CropRepository;
+import com.meztlitech.agrobitacora.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class AdminService {
+
+    private final CropRepository cropRepository;
+    private final UserRepository userRepository;
+    private final AuthenticationService authenticationService;
+
+    public CropEntity createCropForUser(Long userId, CropDto cropDto) {
+        UserEntity user = userRepository.findById(userId).orElseThrow();
+        CropEntity crop = new CropEntity();
+        crop.setAlias(cropDto.getAlias());
+        crop.setLatitud(cropDto.getLatitud());
+        crop.setLongitud(cropDto.getLongitud());
+        crop.setLocation(cropDto.getLocation());
+        crop.setArea(cropDto.getArea());
+        crop.setFlowerName(cropDto.getFlowerName());
+        crop.setNumberPlants(cropDto.getNumberPlants());
+        crop.setUser(user);
+        return cropRepository.save(crop);
+    }
+
+    public List<UserEntity> getUsers() {
+        return userRepository.findAll();
+    }
+
+    public UserResponse createUser(UserDto userDto) {
+        return authenticationService.create(userDto);
+    }
+
+    public ActionStatusResponse changePassword(Long id, UserDto userDto) {
+        return authenticationService.change_password(id, userDto);
+    }
+
+    public ActionStatusResponse deleteUser(Long id) {
+        return authenticationService.delete(id);
+    }
+
+    public AdminCountsDto getCounts() {
+        AdminCountsDto dto = new AdminCountsDto();
+        dto.setUsers(userRepository.count());
+        dto.setCrops(cropRepository.count());
+        return dto;
+    }
+}


### PR DESCRIPTION
## Summary
- add `AdminController` with endpoints for admin operations
- implement `AdminService` to manage crops and users
- provide simple counts via `AdminCountsDto`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684cca7e79ac8323ae25a7d830e8920a