### PR TITLE
Add WhatsApp integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ registro disponible se guarda como `cropId` en `localStorage`, lo cual se usa
 para consultar la información asociada en las demás páginas. Si el usuario es
 Productor, ese `cropId` también se envía como cabecera HTTP en todas las
 peticiones para que el servidor pueda identificar el cultivo seleccionado.
+
+## Integración con WhatsApp
+
+Se añadió un nuevo servicio y controlador para enviar mensajes mediante la API de WhatsApp Business. Para habilitarlo es necesario definir las variables de entorno `WHATSAPP_TOKEN` y `WHATSAPP_PHONE_NUMBER_ID` o establecer los valores correspondientes en `application.properties`.
+
+El endpoint `/whatsapp/send` permite enviar un mensaje simple especificando los parámetros `to` (número de destino) y `message`.
+

--- a/src/main/java/com/meztlitech/agrobitacora/config/RestTemplateConfig.java
+++ b/src/main/java/com/meztlitech/agrobitacora/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.meztlitech.agrobitacora.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/meztlitech/agrobitacora/controller/WhatsAppController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/WhatsAppController.java
@@ -1,0 +1,35 @@
+package com.meztlitech.agrobitacora.controller;
+
+import com.meztlitech.agrobitacora.service.WhatsAppService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/whatsapp")
+@RequiredArgsConstructor
+@Log4j2
+public class WhatsAppController {
+
+    private final WhatsAppService whatsAppService;
+
+    @PostMapping("/send")
+    public ResponseEntity<Void> send(@RequestParam String to, @RequestParam String message) {
+        whatsAppService.sendMessage(to, message);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/webhook")
+    public ResponseEntity<Void> webhook(@RequestBody Map<String, Object> payload) {
+        log.info("Webhook payload received: {}", payload);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/webhook")
+    public ResponseEntity<String> verify(@RequestParam("hub.challenge") String challenge) {
+        return ResponseEntity.ok(challenge);
+    }
+}

--- a/src/main/java/com/meztlitech/agrobitacora/service/WhatsAppService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/WhatsAppService.java
@@ -1,0 +1,54 @@
+package com.meztlitech.agrobitacora.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class WhatsAppService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${whatsapp.token:}")
+    private String token;
+
+    @Value("${whatsapp.phone-number-id:}")
+    private String phoneNumberId;
+
+    private static final String GRAPH_URL = "https://graph.facebook.com/v18.0/";
+
+    public void sendMessage(String to, String message) {
+        if (token == null || token.isBlank() || phoneNumberId == null || phoneNumberId.isBlank()) {
+            log.warn("WhatsApp credentials are not configured");
+            return;
+        }
+        String url = GRAPH_URL + phoneNumberId + "/messages";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(token);
+
+        Map<String, Object> text = new HashMap<>();
+        text.put("body", message);
+        Map<String, Object> body = new HashMap<>();
+        body.put("messaging_product", "whatsapp");
+        body.put("to", to);
+        body.put("type", "text");
+        body.put("text", text);
+
+        try {
+            restTemplate.postForEntity(url, new HttpEntity<>(body, headers), String.class);
+        } catch (Exception ex) {
+            log.error("Error sending WhatsApp message", ex);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,9 @@ spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
 
 spring.messages.basename=messages
+
+# WhatsApp integration
+whatsapp.token=${WHATSAPP_TOKEN:}
+whatsapp.phone-number-id=${WHATSAPP_PHONE_NUMBER_ID:}
+
+


### PR DESCRIPTION
## Summary
- integrate WhatsApp Business API using RestTemplate
- add WhatsApp service and controller
- expose `/whatsapp/send` endpoint
- add configuration and document new setup

## Testing
- `mvn test` *(fails: Could not download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685199528ec48323977fddc33089902e