### PR TITLE
Add toast notifications for login and save actions

### DIFF
--- a/src/main/resources/templates/fragments/nav.html
+++ b/src/main/resources/templates/fragments/nav.html
@@ -11,3 +11,6 @@
     </div>
   </div>
 </nav>
+<div aria-live="polite" aria-atomic="true" class="position-fixed top-0 end-0 p-3" style="z-index: 11">
+  <div id="toast-container"></div>
+</div>

--- a/src/main/resources/templates/fragments/nav.html
+++ b/src/main/resources/templates/fragments/nav.html
@@ -10,7 +10,7 @@
       </div>
     </div>
   </div>
+  <div aria-live="polite" aria-atomic="true" class="position-fixed top-0 end-0 p-3" style="z-index: 11">
+    <div id="toast-container"></div>
+  </div>
 </nav>
-<div aria-live="polite" aria-atomic="true" class="position-fixed top-0 end-0 p-3" style="z-index: 11">
-  <div id="toast-container"></div>
-</div>


### PR DESCRIPTION
## Summary
- implement `App.notify` helper for Bootstrap toasts
- show toast notifications on form submissions and deletions
- add toast container to navigation fragment

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68656120ac3083238d1043867475eca4