### PR TITLE
Add producer and crop selection for engineers

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/controller/EngineerController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/EngineerController.java
@@ -1,0 +1,64 @@
+package com.meztlitech.agrobitacora.controller;
+
+import com.meztlitech.agrobitacora.dto.filters.CropFilter;
+import com.meztlitech.agrobitacora.entity.CropEntity;
+import com.meztlitech.agrobitacora.entity.RoleEntity;
+import com.meztlitech.agrobitacora.entity.UserEntity;
+import com.meztlitech.agrobitacora.service.EngineerService;
+import com.meztlitech.agrobitacora.service.JwtService;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpServerErrorException;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/engineer")
+@RequiredArgsConstructor
+@Log4j2
+public class EngineerController {
+
+    private final EngineerService engineerService;
+    private final JwtService jwtService;
+    private static final String ROLE_INGENIERO = "Ingeniero";
+
+    private void validateEngineer(String token) {
+        Claims claims = jwtService.decodeToken(token);
+        Object roleObj = claims.get("role");
+        String role = null;
+        if (roleObj instanceof Map) {
+            Object name = ((Map<?,?>) roleObj).get("name");
+            if (name != null) role = name.toString();
+        } else if (roleObj != null) {
+            role = roleObj.toString();
+        }
+        if (!ROLE_INGENIERO.equals(role)) {
+            throw new HttpServerErrorException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+    }
+
+    @GetMapping("/producers")
+    public ResponseEntity<List<UserEntity>> producers(@RequestHeader("Authorization") String token) {
+        validateEngineer(token);
+        return ResponseEntity.ok(engineerService.getProducers());
+    }
+
+    @GetMapping("/crops")
+    public ResponseEntity<Page<CropEntity>> crops(@RequestParam Long producerId,
+                                                  @RequestParam int page,
+                                                  @RequestParam int size,
+                                                  @RequestHeader("Authorization") String token) {
+        validateEngineer(token);
+        CropFilter filter = new CropFilter(page, size);
+        return ResponseEntity.ok(engineerService.getCrops(producerId, filter));
+    }
+}

--- a/src/main/java/com/meztlitech/agrobitacora/service/EngineerService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/EngineerService.java
@@ -1,0 +1,35 @@
+package com.meztlitech.agrobitacora.service;
+
+import com.meztlitech.agrobitacora.dto.filters.CropFilter;
+import com.meztlitech.agrobitacora.entity.CropEntity;
+import com.meztlitech.agrobitacora.entity.UserEntity;
+import com.meztlitech.agrobitacora.repository.CropRepository;
+import com.meztlitech.agrobitacora.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class EngineerService {
+
+    private final UserRepository userRepository;
+    private final CropRepository cropRepository;
+
+    private static final String ROLE_PRODUCTOR = "Productor";
+
+    public List<UserEntity> getProducers() {
+        return userRepository.findByRoleName(ROLE_PRODUCTOR);
+    }
+
+    public Page<CropEntity> getCrops(Long producerId, CropFilter filter) {
+        Pageable paging = PageRequest.of(filter.getPage(), filter.getSize());
+        return cropRepository.findAllByUserId(producerId, paging);
+    }
+}

--- a/src/main/java/com/meztlitech/agrobitacora/service/FumigationService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/FumigationService.java
@@ -52,6 +52,7 @@ public class FumigationService {
         if (role.getName().equals(ROLE_PRODUCTOR)) {
             applicationEntity.setApplicationDate(applicationDto.getApplicationDate());
         } else if (role.getName().equals(ROLE_INGENIERO)){
+            applicationEntity.setApplicationDate(applicationDto.getApplicationDate());
             applicationEntity.setVisitDate(applicationDto.getVisitDate());
         }
         applicationEntity.setUser(userRepository.findById(userId).orElseThrow());

--- a/src/main/java/com/meztlitech/agrobitacora/util/CropUtil.java
+++ b/src/main/java/com/meztlitech/agrobitacora/util/CropUtil.java
@@ -18,9 +18,20 @@ public class CropUtil {
 
     public Claims validateCropByUser(String token, Long cropId) {
         Claims claims = jwtService.decodeToken(token);
-        Long userId = Long.parseLong(claims.get("id").toString());
-        if (!cropRepository.findByIdAndUserId(cropId, userId).isPresent()) {
-            throw new HttpServerErrorException(HttpStatus.PRECONDITION_FAILED, "The Crop can't be use by this user");
+        Object roleObj = claims.get("role");
+        String role = null;
+        if (roleObj instanceof java.util.Map) {
+            java.util.Map<?,?> map = (java.util.Map<?,?>) roleObj;
+            Object name = map.get("name");
+            if (name != null) role = name.toString();
+        } else if (roleObj != null) {
+            role = roleObj.toString();
+        }
+        if (!"Ingeniero".equals(role)) {
+            Long userId = Long.parseLong(claims.get("id").toString());
+            if (!cropRepository.findByIdAndUserId(cropId, userId).isPresent()) {
+                throw new HttpServerErrorException(HttpStatus.PRECONDITION_FAILED, "The Crop can't be use by this user");
+            }
         }
         return claims;
     }

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -252,24 +252,65 @@
         }
 
         async function loadCropSelect() {
-            if (localStorage.getItem('role') !== 'Productor') return;
-            const $select = $('#crop-select');
-            if ($select.length === 0) return;
-            const res = await fetch('/crop/all?page=0&size=20');
-            if (!res.ok) return;
-            const data = await res.json();
-            const items = Array.isArray(data) ? data : (data.content || []);
-            $select.empty();
-            items.forEach(c => $select.append(`<option value="${c.id}">${c.alias}</option>`));
-            if (!localStorage.getItem('cropId') && items.length) {
-                localStorage.setItem('cropId', items[0].id);
+            const role = localStorage.getItem('role');
+            const $cropSelect = $('#crop-select');
+            if ($cropSelect.length === 0) return;
+            if (role === 'Productor') {
+                const res = await fetch('/crop/all?page=0&size=20');
+                if (!res.ok) return;
+                const data = await res.json();
+                const items = Array.isArray(data) ? data : (data.content || []);
+                $cropSelect.empty();
+                items.forEach(c => $cropSelect.append(`<option value="${c.id}">${c.alias}</option>`));
+                if (!localStorage.getItem('cropId') && items.length) {
+                    localStorage.setItem('cropId', items[0].id);
+                }
+                $cropSelect.val(localStorage.getItem('cropId'));
+                $cropSelect.removeClass('d-none');
+                $cropSelect.on('change', function () {
+                    localStorage.setItem('cropId', this.value);
+                    location.reload();
+                });
+            } else if (role === 'Ingeniero') {
+                const $producerSelect = $('#producer-select');
+                if ($producerSelect.length === 0) return;
+                const resProd = await fetch('/engineer/producers');
+                if (!resProd.ok) return;
+                const producers = await resProd.json();
+                $producerSelect.empty();
+                producers.forEach(p => $producerSelect.append(`<option value="${p.id}">${p.name}</option>`));
+                let producerId = localStorage.getItem('producerId');
+                if (!producerId && producers.length) {
+                    producerId = producers[0].id;
+                    localStorage.setItem('producerId', producerId);
+                }
+                $producerSelect.val(producerId);
+                async function loadCrops(pid) {
+                    const res = await fetch(`/engineer/crops?producerId=${pid}&page=0&size=20`);
+                    if (!res.ok) return;
+                    const data = await res.json();
+                    const items = Array.isArray(data) ? data : (data.content || []);
+                    $cropSelect.empty();
+                    items.forEach(c => $cropSelect.append(`<option value="${c.id}">${c.alias}</option>`));
+                    if (!localStorage.getItem('cropId') && items.length) {
+                        localStorage.setItem('cropId', items[0].id);
+                    }
+                    $cropSelect.val(localStorage.getItem('cropId'));
+                    $cropSelect.removeClass('d-none');
+                    $cropSelect.on('change', function () {
+                        localStorage.setItem('cropId', this.value);
+                        App.loadData(window.page);
+                    });
+                }
+                if (producerId) {
+                    await loadCrops(producerId);
+                }
+                $producerSelect.removeClass('d-none');
+                $producerSelect.on('change', async function () {
+                    localStorage.setItem('producerId', this.value);
+                    await loadCrops(this.value);
+                });
             }
-            $select.val(localStorage.getItem('cropId'));
-            $select.removeClass('d-none');
-            $select.on('change', function () {
-                localStorage.setItem('cropId', this.value);
-                location.reload();
-            });
         }
 
         function showMenus() {

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -223,7 +223,10 @@
             init.headers = {
                 ...(init.headers || {}),
                 ...(localStorage.getItem('token') ? { 'Authorization': 'Bearer ' + localStorage.getItem('token') } : {}),
-                ...(localStorage.getItem('role') === 'Productor' && localStorage.getItem('cropId') ? { cropId: localStorage.getItem('cropId') } : {})
+                ...(localStorage.getItem('cropId') &&
+                    ['Productor', 'Ingeniero'].includes(localStorage.getItem('role'))
+                    ? { cropId: localStorage.getItem('cropId') }
+                    : {})
             };
             return originalFetch(input, init);
         };
@@ -233,7 +236,7 @@
                 if (localStorage.getItem('token')) {
                     xhr.setRequestHeader('Authorization', 'Bearer ' + localStorage.getItem('token'));
                 }
-                if (localStorage.getItem('role') === 'Productor' && localStorage.getItem('cropId')) {
+                if (['Productor', 'Ingeniero'].includes(localStorage.getItem('role')) && localStorage.getItem('cropId')) {
                     xhr.setRequestHeader('cropId', localStorage.getItem('cropId'));
                 }
             }
@@ -332,10 +335,15 @@
             allow.forEach(sel => $(sel).removeClass('d-none'));
         }
 
-        $('form.api').on('submit', async function (e) {
-            e.preventDefault();
-            const data = App.formDataToObject(this);
-            const method = this.dataset.method || $(this).attr('method') || this.method;
+       $('form.api').on('submit', async function (e) {
+           e.preventDefault();
+            const role = localStorage.getItem('role');
+            if (role === 'Ingeniero' && this.action.includes('/fumigation') && !localStorage.getItem('cropId')) {
+                App.notify('Debe seleccionar un cultivo', 'danger');
+                return;
+            }
+           const data = App.formDataToObject(this);
+           const method = this.dataset.method || $(this).attr('method') || this.method;
             const res = await fetch(this.action, {
                 method,
                 headers: { 'Content-Type': 'application/json' },

--- a/src/main/resources/templates/fragments/nav.html
+++ b/src/main/resources/templates/fragments/nav.html
@@ -2,6 +2,7 @@
   <div class="container-fluid">
     <a class="navbar-brand" th:href="@{/}" th:text="#{nav.title}">Agro Bitácora</a>
     <div class="d-flex ms-auto align-items-center">
+      <select id="producer-select" class="form-select form-select-sm me-2 d-none"></select>
       <select id="crop-select" class="form-select form-select-sm me-2 d-none"></select>
       <div class="navbar-nav">
         <a class="nav-link" th:href="@{?lang=es}">ES</a>

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -7,7 +7,7 @@
   <h1 class="mb-4" th:text="#{fumigation.title}">Fumigation Management</h1>
   <form class="api mb-4" method="post" action="/fumigation">
     <div class="row g-3">
-      <div class="col-md-6">
+      <div class="col-md-6" hidden="true">
         <label class="form-label">Tipo de aplicación</label>
         <select name="applicationType" class="form-select" required>
           <option value="FUMIGACION" th:text="#{app.type.FUMIGACION}">FUMIGACION</option>

--- a/src/main/resources/templates/nutrition.html
+++ b/src/main/resources/templates/nutrition.html
@@ -7,7 +7,7 @@
   <h1 class="mb-4" th:text="#{nutrition.title}">Nutrition Management</h1>
   <form class="api mb-4" method="post" action="/nutrition">
     <div class="row g-3">
-      <div class="col-md-6">
+      <div class="col-md-6" hidden="true">
         <label class="form-label">Tipo de aplicación</label>
         <select name="applicationType" class="form-select" required>
           <option value="FUMIGACION" th:text="#{app.type.FUMIGACION}">FUMIGACION</option>


### PR DESCRIPTION
## Summary
- create EngineerService and controller to list producers and crops
- allow engineers to skip crop validation
- show producer dropdown in nav
- support selecting producer and crop in JS

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68656d7fb83c8323b3ed0c5620004d3c