### PR TITLE
Add offline support for fumigation and nutrition

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ El endpoint `/whatsapp/send` permite enviar un mensaje simple especificando los 
 
 La aplicación incluye soporte básico como [Progressive Web App](https://developer.mozilla.org/es/docs/Web/Progressive_web_apps). Se proporciona un `manifest.webmanifest` (con los iconos en formato base64) y se registra un *service worker* para almacenar en caché los recursos estáticos principales y permitir su uso sin conexión.
 
+### Modo sin conexión
+
+Cuando no haya conexión a internet las fumigaciones y nutriciones creadas se guardarán localmente en el navegador. Al recuperar la red se enviarán automáticamente al servidor. Si se inicia sesión sin conexión, la aplicación mostrará los registros almacenados de forma local.
+
 ## Ejecución local
 
 1. Instala JDK 17 (o superior) y clona este repositorio.


### PR DESCRIPTION
## Summary
- implement local storage queue and sync for fumigation and nutrition
- load local data when offline and save new records for later
- mention offline mode in README

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68684e549d2483238d62616b786ba17a