### PR TITLE
Add detailed info for fumigation and nutrition lists

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/service/FumigationService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/FumigationService.java
@@ -79,7 +79,10 @@ public class FumigationService {
         Pageable paging = PageRequest.of(applicationFilter.getPage(), applicationFilter.getSize());
         Page<ApplicationEntity> pageApp = applicationRepository.findAllByApplicationType(ApplicationType.FUMIGACION, cropId, paging);
         List<ApplicationResponse> content = new ArrayList<>();
-        pageApp.get().forEach(nutrition -> content.add(this.mapNutrition(nutrition, new ArrayList<>())));
+        pageApp.get().forEach(app -> {
+            List<ApplicationDetailEntity> details = applicationDetailRepository.findAllByApplicationId(app.getId());
+            content.add(this.mapNutrition(app, details));
+        });
 
         return new PageImpl<>(content, pageApp.getPageable(), pageApp.getTotalElements());
     }

--- a/src/main/java/com/meztlitech/agrobitacora/service/NutritionService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/NutritionService.java
@@ -79,7 +79,10 @@ public class NutritionService {
         Pageable paging = PageRequest.of(applicationFilter.getPage(), applicationFilter.getSize());
         Page<ApplicationEntity> pageApp = applicationRepository.findAllByApplicationType(ApplicationType.NUTRICION, cropId, paging);
         List<ApplicationResponse> content = new ArrayList<>();
-        pageApp.get().forEach(nutrition -> content.add(this.mapNutrition(nutrition, new ArrayList<>())));
+        pageApp.get().forEach(app -> {
+            List<ApplicationDetailEntity> details = applicationDetailRepository.findAllByApplicationId(app.getId());
+            content.add(this.mapNutrition(app, details));
+        });
 
         return new PageImpl<>(content, pageApp.getPageable(), pageApp.getTotalElements());
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -14,6 +14,7 @@ home.production=Producción
 bill.title=Gestión de Facturas
 crop.title=Gestión de Cultivos
 fumigation.title=Gestión de Fumigaciones
+fumigation.generate.title=Creación de Fumigaciones
 irrigation.title=Gestión de Riegos
 labor.title=Gestión de Labores
 nutrition.title=Gestión de Nutrición

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -14,6 +14,7 @@ home.production=Production
 bill.title=Bill Management
 crop.title=Crop Management
 fumigation.title=Fumigation Management
+fumigation.generate.title=Creation of Fumigation
 irrigation.title=Irrigation Management
 labor.title=Labor Management
 nutrition.title=Nutrition Management

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -163,6 +163,19 @@
         App.renumberProductGroups();
     };
 
+    App.showApplicationDetails = function (app) {
+        const $modal = $('#detailModal');
+        if ($modal.length === 0) return;
+        $modal.find('#app-info').text(`${app.applicationDate || ''} - ${app.detail || ''}`);
+        const $tbody = $modal.find('#detail-table');
+        $tbody.empty();
+        (app.appDetails || []).forEach(d => {
+            $tbody.append(`<tr><td>${d.productName}</td><td>${d.activeIngredient}</td><td>${d.dosis}</td><td>${d.unit}</td><td>${(d.condiciones || []).join(', ')}</td></tr>`);
+        });
+        const modal = new bootstrap.Modal($modal[0]);
+        modal.show();
+    };
+
     function saveLocalData(type, items) {
         console.log(`saveLocalData: storing ${items.length} ${type}s`);
         localStorage.setItem(`${type}s`, JSON.stringify(items));
@@ -282,6 +295,10 @@
             App.fillForm($form[0], item);
             $form.attr('action', `${location.pathname}/${item.id}`);
             $form[0].dataset.method = 'PUT';
+        });
+        $tbody.find('button.show-detail').on('click', function () {
+            const item = JSON.parse(decodeURIComponent($(this).closest('tr').data('item')));
+            App.showApplicationDetails(item);
         });
         if (typeof config.afterLoad === 'function') config.afterLoad(items);
     };

--- a/src/main/resources/static/js/farm.js
+++ b/src/main/resources/static/js/farm.js
@@ -31,13 +31,13 @@ App.registerEntity('production', {
 App.registerEntity('nutrition', {
     url: '/nutrition/all?page=0&size=20',
     headers: () => ({ cropId: localStorage.getItem('cropId') }),
-    buildRow: n => `<tr data-item="${App.enc(n)}"><td>${n.id}</td><td>${n.applicationType}</td><td>${n.applicationDate}</td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`
+    buildRow: n => `<tr data-item="${App.enc(n)}"><td>${n.id}</td><td>${n.applicationDate}</td><td>${n.detail}</td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`
 });
 
 App.registerEntity('fumigation', {
     url: '/fumigation/all?page=0&size=20',
     headers: () => ({ cropId: localStorage.getItem('cropId') }),
-    buildRow: f => `<tr data-item="${App.enc(f)}"><td>${f.id}</td><td>${f.applicationType}</td><td>${f.applicationDate}</td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`,
+    buildRow: f => `<tr data-item="${App.enc(f)}"><td>${f.id}</td><td>${f.applicationDate}</td><td>${f.detail}</td><td>${(f.appDetails || []).map(d => d.productName).join(', ')}</td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`,
     onPageLoad: () => { $('#add-product').on('click', () => App.addProductGroup()); App.addProductGroup(); },
     onEdit: data => { App.setProductGroupCount((data.appDetails && data.appDetails.length) || 1); }
 });

--- a/src/main/resources/static/js/farm.js
+++ b/src/main/resources/static/js/farm.js
@@ -31,13 +31,13 @@ App.registerEntity('production', {
 App.registerEntity('nutrition', {
     url: '/nutrition/all?page=0&size=20',
     headers: () => ({ cropId: localStorage.getItem('cropId') }),
-    buildRow: n => `<tr data-item="${App.enc(n)}"><td>${n.id}</td><td>${n.applicationDate}</td><td>${n.detail}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`
+    buildRow: n => `<tr data-item="${App.enc(n)}"><td>${n.id}</td><td>${n.applicationDate}</td><td>${n.detail}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td></tr>`
 });
 
 App.registerEntity('fumigation', {
     url: '/fumigation/all?page=0&size=20',
     headers: () => ({ cropId: localStorage.getItem('cropId') }),
-    buildRow: f => `<tr data-item="${App.enc(f)}"><td>${f.id}</td><td>${f.applicationDate}</td><td>${f.detail}</td><td>${(f.appDetails || []).map(d => d.productName).join(', ')}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`,
+    buildRow: f => `<tr data-item="${App.enc(f)}"><td>${f.id}</td><td>${f.applicationDate}</td><td>${f.detail}</td><td>${(f.appDetails || []).map(d => d.productName).join(', ')}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td></tr>`,
     onPageLoad: () => { $('#add-product').on('click', () => App.addProductGroup()); App.addProductGroup(); },
     onEdit: data => { App.setProductGroupCount((data.appDetails && data.appDetails.length) || 1); }
 });

--- a/src/main/resources/static/js/farm.js
+++ b/src/main/resources/static/js/farm.js
@@ -31,13 +31,13 @@ App.registerEntity('production', {
 App.registerEntity('nutrition', {
     url: '/nutrition/all?page=0&size=20',
     headers: () => ({ cropId: localStorage.getItem('cropId') }),
-    buildRow: n => `<tr data-item="${App.enc(n)}"><td>${n.id}</td><td>${n.applicationDate}</td><td>${n.detail}</td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`
+    buildRow: n => `<tr data-item="${App.enc(n)}"><td>${n.id}</td><td>${n.applicationDate}</td><td>${n.detail}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`
 });
 
 App.registerEntity('fumigation', {
     url: '/fumigation/all?page=0&size=20',
     headers: () => ({ cropId: localStorage.getItem('cropId') }),
-    buildRow: f => `<tr data-item="${App.enc(f)}"><td>${f.id}</td><td>${f.applicationDate}</td><td>${f.detail}</td><td>${(f.appDetails || []).map(d => d.productName).join(', ')}</td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`,
+    buildRow: f => `<tr data-item="${App.enc(f)}"><td>${f.id}</td><td>${f.applicationDate}</td><td>${f.detail}</td><td>${(f.appDetails || []).map(d => d.productName).join(', ')}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`,
     onPageLoad: () => { $('#add-product').on('click', () => App.addProductGroup()); App.addProductGroup(); },
     onEdit: data => { App.setProductGroupCount((data.appDetails && data.appDetails.length) || 1); }
 });

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -5,6 +5,26 @@
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
   <h1 class="mb-4" th:text="#{fumigation.title}">Fumigation Management</h1>
+
+
+  <table class="table table-striped">
+    <thead>
+    <tr>
+      <th>ID</th>
+      <th>Fecha aplicación</th>
+      <th>Detalle</th>
+      <th>Productos</th>
+      <th>Mostrar</th>
+    </tr>
+    </thead>
+    <tbody>
+    <!-- Aquí se mostrarán las aplicaciones -->
+    </tbody>
+  </table>
+
+  <hr>
+  <h1 class="mb-4" th:text="#{fumigation.generate.title}"></h1>
+
   <form class="api mb-4" method="post" action="/fumigation">
     <div class="row g-3">
       <div class="col-md-6" hidden="true">
@@ -64,21 +84,6 @@
     </div>
     <button type="submit" class="btn btn-success mt-3" th:text="#{create.button}">Crear</button>
   </form>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Fecha aplicación</th>
-        <th>Detalle</th>
-        <th>Productos</th>
-        <th>Mostrar</th>
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      <!-- Aquí se mostrarán las aplicaciones -->
-    </tbody>
-  </table>
   <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
 </div>
 <div class="modal fade" id="detailModal" tabindex="-1" aria-hidden="true">

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -71,6 +71,7 @@
         <th>Fecha aplicación</th>
         <th>Detalle</th>
         <th>Productos</th>
+        <th>Mostrar</th>
         <th></th>
       </tr>
     </thead>
@@ -79,6 +80,31 @@
     </tbody>
   </table>
   <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+</div>
+<div class="modal fade" id="detailModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Detalle de aplicación</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p id="app-info"></p>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Producto</th>
+              <th>Ingrediente activo</th>
+              <th>Dosis</th>
+              <th>Unidad</th>
+              <th>Detalles</th>
+            </tr>
+          </thead>
+          <tbody id="detail-table"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -23,7 +23,7 @@
   </table>
 
   <hr>
-  <h1 class="mb-4" th:text="#{fumigation.generate.title}"></h1>
+  <h3 class="mb-4" th:text="#{fumigation.generate.title}"></h3>
 
   <form class="api mb-4" method="post" action="/fumigation">
     <div class="row g-3">

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -68,8 +68,9 @@
     <thead>
       <tr>
         <th>ID</th>
-        <th>Tipo</th>
-        <th>Fecha</th>
+        <th>Fecha aplicación</th>
+        <th>Detalle</th>
+        <th>Productos</th>
         <th></th>
       </tr>
     </thead>

--- a/src/main/resources/templates/nutrition.html
+++ b/src/main/resources/templates/nutrition.html
@@ -33,8 +33,8 @@
     <thead>
       <tr>
         <th>ID</th>
-        <th>Tipo</th>
-        <th>Fecha</th>
+        <th>Fecha aplicación</th>
+        <th>Detalle</th>
         <th></th>
       </tr>
     </thead>

--- a/src/main/resources/templates/nutrition.html
+++ b/src/main/resources/templates/nutrition.html
@@ -35,6 +35,7 @@
         <th>ID</th>
         <th>Fecha aplicación</th>
         <th>Detalle</th>
+        <th>Mostrar</th>
         <th></th>
       </tr>
     </thead>
@@ -43,6 +44,31 @@
     </tbody>
   </table>
   <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+</div>
+<div class="modal fade" id="detailModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Detalle de aplicación</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p id="app-info"></p>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Producto</th>
+              <th>Ingrediente activo</th>
+              <th>Dosis</th>
+              <th>Unidad</th>
+              <th>Detalles</th>
+            </tr>
+          </thead>
+          <tbody id="detail-table"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>


### PR DESCRIPTION
## Summary
- include detail entities when listing fumigations and nutritions
- show application date, detail and product names in tables
- simplify nutrition and fumigation tables

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68685ecf81988323bcc4ae1aefc0d181