### PR TITLE
Align nutrition with fumigation features

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/service/NutritionService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/NutritionService.java
@@ -53,6 +53,7 @@ public class NutritionService {
         if (role.getName().equals(ROLE_PRODUCTOR)) {
             applicationEntity.setApplicationDate(applicationDto.getApplicationDate());
         } else if (role.getName().equals(ROLE_INGENIERO)){
+            applicationEntity.setApplicationDate(applicationDto.getApplicationDate());
             applicationEntity.setVisitDate(applicationDto.getVisitDate());
         }
         applicationEntity.setUser(userRepository.findById(userId).orElseThrow());

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -15,6 +15,7 @@ bill.title=Gestión de Facturas
 crop.title=Gestión de Cultivos
 fumigation.title=Gestión de Fumigaciones
 fumigation.generate.title=Creación de Fumigaciones
+nutrition.generate.title=Creación de Nutrición
 irrigation.title=Gestión de Riegos
 labor.title=Gestión de Labores
 nutrition.title=Gestión de Nutrición

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -15,6 +15,7 @@ bill.title=Bill Management
 crop.title=Crop Management
 fumigation.title=Fumigation Management
 fumigation.generate.title=Creation of Fumigation
+nutrition.generate.title=Creation of Nutrition
 irrigation.title=Irrigation Management
 labor.title=Labor Management
 nutrition.title=Nutrition Management

--- a/src/main/resources/static/js/farm.js
+++ b/src/main/resources/static/js/farm.js
@@ -28,16 +28,30 @@ App.registerEntity('production', {
     buildRow: p => `<tr data-item="${App.enc(p)}"><td>${p.id}</td><td>${p.productionDate}</td><td></td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`
 });
 
+function hideVisitDate() {
+    if (localStorage.getItem('role') === 'Productor') {
+        const $visit = $('input[name="visitDate"]');
+        $visit.closest('.col-md-6').addClass('d-none');
+        $visit.prop('required', false);
+        const appVal = $('input[name="applicationDate"]').val();
+        if (appVal && !$visit.val()) {
+            $visit.val(appVal);
+        }
+    }
+}
+
 App.registerEntity('nutrition', {
     url: '/nutrition/all?page=0&size=20',
     headers: () => ({ cropId: localStorage.getItem('cropId') }),
-    buildRow: n => `<tr data-item="${App.enc(n)}"><td>${n.id}</td><td>${n.applicationDate}</td><td>${n.detail}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td></tr>`
+    buildRow: n => `<tr data-item="${App.enc(n)}"><td>${n.id}</td><td>${n.applicationDate}</td><td>${n.detail}</td><td>${(n.appDetails || []).map(d => d.productName).join(', ')}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td></tr>`,
+    onPageLoad: () => { hideVisitDate(); $('#add-product').on('click', () => App.addProductGroup()); App.addProductGroup(); },
+    onEdit: data => { hideVisitDate(); App.setProductGroupCount((data.appDetails && data.appDetails.length) || 1); }
 });
 
 App.registerEntity('fumigation', {
     url: '/fumigation/all?page=0&size=20',
     headers: () => ({ cropId: localStorage.getItem('cropId') }),
     buildRow: f => `<tr data-item="${App.enc(f)}"><td>${f.id}</td><td>${f.applicationDate}</td><td>${f.detail}</td><td>${(f.appDetails || []).map(d => d.productName).join(', ')}</td><td><button class='show-detail btn btn-sm btn-info'>Mostrar</button></td></tr>`,
-    onPageLoad: () => { $('#add-product').on('click', () => App.addProductGroup()); App.addProductGroup(); },
-    onEdit: data => { App.setProductGroupCount((data.appDetails && data.appDetails.length) || 1); }
+    onPageLoad: () => { hideVisitDate(); $('#add-product').on('click', () => App.addProductGroup()); App.addProductGroup(); },
+    onEdit: data => { hideVisitDate(); App.setProductGroupCount((data.appDetails && data.appDetails.length) || 1); }
 });

--- a/src/main/resources/templates/admin-engineers.html
+++ b/src/main/resources/templates/admin-engineers.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{admin.engineers.title}">Ingenieros</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/admin}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{admin.engineers.title}"></span>
+  </h1>
   <div id="admin-counts" class="mb-4"></div>
   <form id="admin-engineer-form" class="api mb-4" method="post" action="/api/admin/engineers">
     <div class="row g-3">
@@ -46,11 +49,6 @@
       <!-- engineer rows -->
     </tbody>
   </table>
-  <p>
-    <a th:href="@{/admin}" class="btn btn-secondary">
-      &larr; <span th:text="#{admin.menu.back}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div th:replace="~{fragments/scripts :: admin-scripts}"></div>
 </body>

--- a/src/main/resources/templates/admin-engineers.html
+++ b/src/main/resources/templates/admin-engineers.html
@@ -46,7 +46,11 @@
       <!-- engineer rows -->
     </tbody>
   </table>
-  <p><a th:href="@{/admin}" th:text="#{admin.menu.back}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/admin}" class="btn btn-secondary">
+      &larr; <span th:text="#{admin.menu.back}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div th:replace="~{fragments/scripts :: admin-scripts}"></div>
 </body>

--- a/src/main/resources/templates/admin-users.html
+++ b/src/main/resources/templates/admin-users.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{admin.users.title}">Usuarios</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/admin}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{admin.users.title}"></span>
+  </h1>
   <div id="admin-counts" class="mb-4"></div>
   <form id="admin-user-form" class="api mb-4" method="post" action="/api/admin/users">
     <div class="row g-3">
@@ -47,11 +50,6 @@
       <!-- user rows -->
     </tbody>
   </table>
-  <p>
-    <a th:href="@{/admin}" class="btn btn-secondary">
-      &larr; <span th:text="#{admin.menu.back}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div th:replace="~{fragments/scripts :: admin-scripts}"></div>
 </body>

--- a/src/main/resources/templates/admin-users.html
+++ b/src/main/resources/templates/admin-users.html
@@ -47,7 +47,11 @@
       <!-- user rows -->
     </tbody>
   </table>
-  <p><a th:href="@{/admin}" th:text="#{admin.menu.back}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/admin}" class="btn btn-secondary">
+      &larr; <span th:text="#{admin.menu.back}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div th:replace="~{fragments/scripts :: admin-scripts}"></div>
 </body>

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -5,7 +5,6 @@
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
   <h1 class="mb-4">
-    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
     <span th:text="#{auth.title}"></span>
   </h1>
   <div class="row">

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{auth.title}">Auth Management</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{auth.title}"></span>
+  </h1>
   <div class="row">
     <div class="col-md-6">
       <h2 th:text="#{sign.in}">Sign In</h2>
@@ -43,11 +46,6 @@
       </form>
     </div>
   </div>
-  <p class="mt-3">
-    <a th:href="@{/}" class="btn btn-secondary">
-      &larr; <span th:text="#{link.home}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div th:replace="~{fragments/scripts :: base-scripts}"></div>
 </body>

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -43,7 +43,11 @@
       </form>
     </div>
   </div>
-  <p class="mt-3"><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+  <p class="mt-3">
+    <a th:href="@{/}" class="btn btn-secondary">
+      &larr; <span th:text="#{link.home}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div th:replace="~{fragments/scripts :: base-scripts}"></div>
 </body>

--- a/src/main/resources/templates/bill.html
+++ b/src/main/resources/templates/bill.html
@@ -39,7 +39,11 @@
       <!-- Aquí se mostrarán las facturas -->
     </tbody>
   </table>
-  <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/}" class="btn btn-secondary">
+      &larr; <span th:text="#{link.home}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/bill.html
+++ b/src/main/resources/templates/bill.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{bill.title}">Bill Management</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{bill.title}"></span>
+  </h1>
   <form class="api mb-4" method="post" action="/bill">
     <div class="mb-3">
       <label class="form-label">Concepto</label>
@@ -39,11 +42,6 @@
       <!-- Aquí se mostrarán las facturas -->
     </tbody>
   </table>
-  <p>
-    <a th:href="@{/}" class="btn btn-secondary">
-      &larr; <span th:text="#{link.home}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/crop.html
+++ b/src/main/resources/templates/crop.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{crop.title}">Crop Management</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{crop.title}"></span>
+  </h1>
   <form class="api mb-4" method="post" action="/crop">
     <div class="row g-3">
       <div class="col-md-6">
@@ -54,11 +57,6 @@
       <!-- Aquí se listarán los cultivos -->
     </tbody>
   </table>
-  <p>
-    <a th:href="@{/}" class="btn btn-secondary">
-      &larr; <span th:text="#{link.home}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/crop.html
+++ b/src/main/resources/templates/crop.html
@@ -54,7 +54,11 @@
       <!-- Aquí se listarán los cultivos -->
     </tbody>
   </table>
-  <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/}" class="btn btn-secondary">
+      &larr; <span th:text="#{link.home}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -96,3 +96,23 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
+        <p id="app-info"></p>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Producto</th>
+              <th>Ingrediente activo</th>
+              <th>Dosis</th>
+              <th>Unidad</th>
+              <th>Detalles</th>
+            </tr>
+          </thead>
+          <tbody id="detail-table"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+<div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -84,7 +84,11 @@
     </div>
     <button type="submit" class="btn btn-success mt-3" th:text="#{create.button}">Crear</button>
   </form>
-  <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/}" class="btn btn-secondary">
+      &larr; <span th:text="#{link.home}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div class="modal fade" id="detailModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{fumigation.title}">Fumigation Management</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{fumigation.title}"></span>
+  </h1>
 
 
   <table class="table table-striped">
@@ -84,11 +87,6 @@
     </div>
     <button type="submit" class="btn btn-success mt-3" th:text="#{create.button}">Crear</button>
   </form>
-  <p>
-    <a th:href="@{/}" class="btn btn-secondary">
-      &larr; <span th:text="#{link.home}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div class="modal fade" id="detailModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">
@@ -98,23 +96,3 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <p id="app-info"></p>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Producto</th>
-              <th>Ingrediente activo</th>
-              <th>Dosis</th>
-              <th>Unidad</th>
-              <th>Detalles</th>
-            </tr>
-          </thead>
-          <tbody id="detail-table"></tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-</div>
-<div th:replace="~{fragments/scripts :: farm-scripts}"></div>
-</body>
-</html>

--- a/src/main/resources/templates/irrigation.html
+++ b/src/main/resources/templates/irrigation.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{irrigation.title}">Irrigation Management</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{irrigation.title}"></span>
+  </h1>
   <form class="api mb-4" method="post" action="/irrigation">
     <div class="row g-3">
       <div class="col-md-6">
@@ -40,11 +43,6 @@
       <!-- Aquí se listarán los riegos -->
     </tbody>
   </table>
-  <p>
-    <a th:href="@{/}" class="btn btn-secondary">
-      &larr; <span th:text="#{link.home}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/irrigation.html
+++ b/src/main/resources/templates/irrigation.html
@@ -40,7 +40,11 @@
       <!-- Aquí se listarán los riegos -->
     </tbody>
   </table>
-  <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/}" class="btn btn-secondary">
+      &larr; <span th:text="#{link.home}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/labor.html
+++ b/src/main/resources/templates/labor.html
@@ -43,7 +43,11 @@
       <!-- Aquí se mostrarán las labores -->
     </tbody>
   </table>
-  <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/}" class="btn btn-secondary">
+      &larr; <span th:text="#{link.home}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/labor.html
+++ b/src/main/resources/templates/labor.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{labor.title}">Labor Management</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{labor.title}"></span>
+  </h1>
   <form class="api mb-4" method="post" action="/labor">
     <div class="row g-3">
       <div class="col-md-6">
@@ -43,11 +46,6 @@
       <!-- Aquí se mostrarán las labores -->
     </tbody>
   </table>
-  <p>
-    <a th:href="@{/}" class="btn btn-secondary">
-      &larr; <span th:text="#{link.home}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/nutrition.html
+++ b/src/main/resources/templates/nutrition.html
@@ -5,6 +5,8 @@
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
   <h1 class="mb-4" th:text="#{nutrition.title}">Nutrition Management</h1>
+  <hr>
+  <h3 class="mb-4" th:text="#{nutrition.generate.title}"></h3>
   <form class="api mb-4" method="post" action="/nutrition">
     <div class="row g-3">
       <div class="col-md-6" hidden="true">
@@ -26,6 +28,41 @@
         <label class="form-label">Detalle</label>
         <textarea name="detail" class="form-control" required></textarea>
       </div>
+      <div class="col-12">
+        <hr>
+        <h5>Productos</h5>
+      </div>
+      <div id="products"></div>
+      <div class="col-12">
+        <button type="button" id="add-product" class="btn btn-secondary btn-sm">Agregar producto</button>
+      </div>
+      <template id="product-template">
+        <div class="row g-3 product-item border p-2 mt-2">
+          <div class="col-md-6">
+            <label class="form-label">Nombre del producto</label>
+            <input type="text" data-field="productName" class="form-control" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Ingrediente activo</label>
+            <input type="text" data-field="activeIngredient" class="form-control" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Dosis</label>
+            <input type="number" data-field="dosis" class="form-control" required>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Unidad</label>
+            <input type="text" data-field="unit" class="form-control" required>
+          </div>
+          <div class="col-12">
+            <label class="form-label">Condiciones (separadas por coma)</label>
+            <input type="text" data-field="condiciones" data-array="csv" class="form-control">
+          </div>
+          <div class="col-12 text-end">
+            <button type="button" class="btn btn-danger btn-sm remove-product">Eliminar</button>
+          </div>
+        </div>
+      </template>
     </div>
     <button type="submit" class="btn btn-success mt-3" th:text="#{create.button}">Crear</button>
   </form>
@@ -35,8 +72,8 @@
         <th>ID</th>
         <th>Fecha aplicación</th>
         <th>Detalle</th>
+        <th>Productos</th>
         <th>Mostrar</th>
-        <th></th>
       </tr>
     </thead>
     <tbody>

--- a/src/main/resources/templates/nutrition.html
+++ b/src/main/resources/templates/nutrition.html
@@ -92,3 +92,23 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
+        <p id="app-info"></p>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Producto</th>
+              <th>Ingrediente activo</th>
+              <th>Dosis</th>
+              <th>Unidad</th>
+              <th>Detalles</th>
+            </tr>
+          </thead>
+          <tbody id="detail-table"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+<div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/nutrition.html
+++ b/src/main/resources/templates/nutrition.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{nutrition.title}">Nutrition Management</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{nutrition.title}"></span>
+  </h1>
   <hr>
   <h3 class="mb-4" th:text="#{nutrition.generate.title}"></h3>
   <form class="api mb-4" method="post" action="/nutrition">
@@ -80,11 +83,6 @@
       <!-- Aquí se mostrarán las aplicaciones nutricionales -->
     </tbody>
   </table>
-  <p>
-    <a th:href="@{/}" class="btn btn-secondary">
-      &larr; <span th:text="#{link.home}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div class="modal fade" id="detailModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">
@@ -94,23 +92,3 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <p id="app-info"></p>
-        <table class="table">
-          <thead>
-            <tr>
-              <th>Producto</th>
-              <th>Ingrediente activo</th>
-              <th>Dosis</th>
-              <th>Unidad</th>
-              <th>Detalles</th>
-            </tr>
-          </thead>
-          <tbody id="detail-table"></tbody>
-        </table>
-      </div>
-    </div>
-  </div>
-</div>
-<div th:replace="~{fragments/scripts :: farm-scripts}"></div>
-</body>
-</html>

--- a/src/main/resources/templates/nutrition.html
+++ b/src/main/resources/templates/nutrition.html
@@ -80,7 +80,11 @@
       <!-- Aquí se mostrarán las aplicaciones nutricionales -->
     </tbody>
   </table>
-  <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/}" class="btn btn-secondary">
+      &larr; <span th:text="#{link.home}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div class="modal fade" id="detailModal" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-lg">

--- a/src/main/resources/templates/production.html
+++ b/src/main/resources/templates/production.html
@@ -26,7 +26,11 @@
       <!-- Aquí se mostrarán las producciones -->
     </tbody>
   </table>
-  <p><a th:href="@{/}" th:text="#{link.home}">Volver al inicio</a></p>
+  <p>
+    <a th:href="@{/}" class="btn btn-secondary">
+      &larr; <span th:text="#{link.home}">Volver al inicio</span>
+    </a>
+  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>

--- a/src/main/resources/templates/production.html
+++ b/src/main/resources/templates/production.html
@@ -4,7 +4,10 @@
 <body>
 <nav th:replace="~{fragments/nav :: nav}"></nav>
 <div class="container mt-4">
-  <h1 class="mb-4" th:text="#{production.title}">Production Management</h1>
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{production.title}"></span>
+  </h1>
   <form class="api mb-4" method="post" action="/production">
     <div class="row g-3">
       <div class="col-md-6">
@@ -26,11 +29,6 @@
       <!-- Aquí se mostrarán las producciones -->
     </tbody>
   </table>
-  <p>
-    <a th:href="@{/}" class="btn btn-secondary">
-      &larr; <span th:text="#{link.home}">Volver al inicio</span>
-    </a>
-  </p>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
 </body>


### PR DESCRIPTION
## Summary
- allow engineers to record both visit and application dates for nutrition
- show nutrition creation section with product details similar to fumigation
- add translations for the nutrition creation title
- hide visit date for Producer role on nutrition and fumigation pages
- display nutrition products in listings

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abd63ad7083238b448f42ab113a5a