### PR TITLE
Add weather footer with Open Meteo API

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/config/SecurityConfiguration.java
+++ b/src/main/java/com/meztlitech/agrobitacora/config/SecurityConfiguration.java
@@ -64,7 +64,7 @@ public class SecurityConfiguration {
                                 "/bill", "/crop", "/fumigation",
                                 "/irrigation", "/labor", "/nutrition",
                                 "/production", "/admin", "/admin/**",
-                                "/js/**" ,"/home").permitAll()
+                                "/js/**" ,"/home", "/weather/**").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(manager -> manager.sessionCreationPolicy(STATELESS))
                 .authenticationProvider(authenticationProvider()).addFilterBefore(

--- a/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
@@ -31,6 +31,7 @@ public class WeatherController {
         if (info == null) {
             return ResponseEntity.noContent().build();
         }
+        info.setLocation(crop.getLocation());
         return ResponseEntity.ok(info);
     }
 }

--- a/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
@@ -1,0 +1,36 @@
+package com.meztlitech.agrobitacora.controller;
+
+import com.meztlitech.agrobitacora.entity.CropEntity;
+import com.meztlitech.agrobitacora.repository.CropRepository;
+import com.meztlitech.agrobitacora.service.WeatherService;
+import com.meztlitech.agrobitacora.util.CropUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/weather")
+@RequiredArgsConstructor
+public class WeatherController {
+
+    private final WeatherService weatherService;
+    private final CropRepository cropRepository;
+    private final CropUtil cropUtil;
+
+    @GetMapping
+    public ResponseEntity<WeatherService.WeatherInfo> getWeather(
+            @RequestHeader(value = "cropId") Long cropId,
+            @RequestHeader(value = "Authorization") String token) {
+        cropUtil.validateCropByUser(token, cropId);
+        CropEntity crop = cropRepository.findById(cropId).orElseThrow();
+        WeatherService.WeatherInfo info = weatherService.getWeather(
+                crop.getLatitud(), crop.getLongitud());
+        if (info == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(info);
+    }
+}

--- a/src/main/java/com/meztlitech/agrobitacora/service/WeatherService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/WeatherService.java
@@ -1,0 +1,55 @@
+package com.meztlitech.agrobitacora.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class WeatherService {
+
+    private final RestTemplate restTemplate;
+
+    public WeatherInfo getWeather(double latitude, double longitude) {
+        String url = "https://api.open-meteo.com/v1/forecast?latitude=" + latitude +
+                "&longitude=" + longitude + "&current_weather=true";
+        try {
+            Map<?, ?> resp = restTemplate.getForObject(url, Map.class);
+            if (resp != null && resp.containsKey("current_weather")) {
+                Object cwObj = resp.get("current_weather");
+                if (cwObj instanceof Map<?, ?> cw) {
+                    Double temp = toDouble(cw.get("temperature"));
+                    Double wind = toDouble(cw.get("windspeed"));
+                    return new WeatherInfo(temp, wind);
+                }
+            }
+        } catch (Exception ex) {
+            log.error("Error fetching weather", ex);
+        }
+        return null;
+    }
+
+    private Double toDouble(Object obj) {
+        if (obj instanceof Number n) {
+            return n.doubleValue();
+        }
+        try {
+            return Double.parseDouble(obj.toString());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class WeatherInfo {
+        private Double temperature;
+        private Double windspeed;
+    }
+}

--- a/src/main/java/com/meztlitech/agrobitacora/service/WeatherService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/WeatherService.java
@@ -26,7 +26,7 @@ public class WeatherService {
                 if (cwObj instanceof Map<?, ?> cw) {
                     Double temp = toDouble(cw.get("temperature"));
                     Double wind = toDouble(cw.get("windspeed"));
-                    return new WeatherInfo(temp, wind);
+                    return new WeatherInfo(temp, wind, "Unknown");
                 }
             }
         } catch (Exception ex) {
@@ -51,5 +51,6 @@ public class WeatherService {
     public static class WeatherInfo {
         private Double temperature;
         private Double windspeed;
+        private String location = "Unknown";
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -46,3 +46,5 @@ bill.kind.IRRIGATION=Riego
 bill.kind.LABOR=Labor
 bill.kind.NUTRITION=Nutrición
 bill.kind.OTHER=Otros
+
+weather.info=Clima

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -46,3 +46,5 @@ bill.kind.IRRIGATION=Irrigation
 bill.kind.LABOR=Labor
 bill.kind.NUTRITION=Nutrition
 bill.kind.OTHER=Other
+
+weather.info=Weather

--- a/src/main/resources/static/js/weather.js
+++ b/src/main/resources/static/js/weather.js
@@ -3,9 +3,15 @@
         const el = document.getElementById('weather');
         if (!el) return;
         const cropId = localStorage.getItem('cropId');
-        if (!cropId || !navigator.onLine) return;
+        const token = localStorage.getItem('token');
+        if (!cropId || !token || !navigator.onLine) return;
         try {
-            const res = await fetch('/weather', { headers: { cropId } });
+            const res = await fetch('/weather', {
+                headers: {
+                    cropId,
+                    Authorization: 'Bearer ' + token
+                }
+            });
             if (!res.ok) return;
             const data = await res.json();
             if (data && data.temperature !== undefined) {

--- a/src/main/resources/static/js/weather.js
+++ b/src/main/resources/static/js/weather.js
@@ -17,7 +17,8 @@
             if (data && data.temperature !== undefined) {
                 const t = data.temperature.toFixed(1);
                 const w = data.windspeed != null ? data.windspeed.toFixed(1) : '';
-                el.textContent = `${t}°C` + (w ? ` | ${w} km/h` : '');
+                const l = data.location != null ? data.location : 'Unknown';
+                el.textContent = `${l}  |°|  ${t}°C` + (w ? `  |°|  ${w} km/h` : '');
             }
         } catch (e) {
             console.log('weather error', e);

--- a/src/main/resources/static/js/weather.js
+++ b/src/main/resources/static/js/weather.js
@@ -1,0 +1,22 @@
+(function () {
+    App.loadWeather = async function () {
+        const el = document.getElementById('weather');
+        if (!el) return;
+        const cropId = localStorage.getItem('cropId');
+        if (!cropId || !navigator.onLine) return;
+        try {
+            const res = await fetch('/weather', { headers: { cropId } });
+            if (!res.ok) return;
+            const data = await res.json();
+            if (data && data.temperature !== undefined) {
+                const t = data.temperature.toFixed(1);
+                const w = data.windspeed != null ? data.windspeed.toFixed(1) : '';
+                el.textContent = `${t}°C` + (w ? ` | ${w} km/h` : '');
+            }
+        } catch (e) {
+            console.log('weather error', e);
+        }
+    };
+
+    document.addEventListener('DOMContentLoaded', () => App.loadWeather());
+})();

--- a/src/main/resources/static/sw.js
+++ b/src/main/resources/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'agrobitacora-cache-v3';
+const CACHE_NAME = 'agrobitacora-cache-v4';
 const URLS_TO_CACHE = [
   '/',
   '/home',
@@ -16,6 +16,7 @@ const URLS_TO_CACHE = [
   '/manifest.webmanifest',
   '/js/app.js',
   '/js/pwa.js',
+  '/js/weather.js',
   '/js/common.js',
   '/js/farm.js',
   '/js/admin.js',

--- a/src/main/resources/templates/admin-engineers.html
+++ b/src/main/resources/templates/admin-engineers.html
@@ -51,5 +51,6 @@
   </table>
 </div>
 <div th:replace="~{fragments/scripts :: admin-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/admin-users.html
+++ b/src/main/resources/templates/admin-users.html
@@ -52,5 +52,6 @@
   </table>
 </div>
 <div th:replace="~{fragments/scripts :: admin-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -12,5 +12,6 @@
   <div id="admin-counts" class="mb-4"></div>
 </div>
 <div th:replace="~{fragments/scripts :: admin-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -47,6 +47,5 @@
   </div>
 </div>
 <div th:replace="~{fragments/scripts :: base-scripts}"></div>
-<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -47,5 +47,6 @@
   </div>
 </div>
 <div th:replace="~{fragments/scripts :: base-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/bill.html
+++ b/src/main/resources/templates/bill.html
@@ -44,5 +44,6 @@
   </table>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/crop.html
+++ b/src/main/resources/templates/crop.html
@@ -59,5 +59,6 @@
   </table>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,0 +1,3 @@
+<footer th:fragment="footer" class="bg-light text-center py-2 mt-4">
+    <span id="weather" th:text="#{weather.info}"></span>
+</footer>

--- a/src/main/resources/templates/fragments/scripts.html
+++ b/src/main/resources/templates/fragments/scripts.html
@@ -4,6 +4,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script th:src="@{/js/common.js}"></script>
     <script th:src="@{/js/pwa.js}"></script>
+    <script th:src="@{/js/weather.js}"></script>
 </th:block>
 
 <th:block th:fragment="farm-scripts">

--- a/src/main/resources/templates/fumigation.html
+++ b/src/main/resources/templates/fumigation.html
@@ -114,5 +114,6 @@
   </div>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -17,5 +17,6 @@
   </div>
 </div>
 <div th:replace="~{fragments/scripts :: base-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/irrigation.html
+++ b/src/main/resources/templates/irrigation.html
@@ -45,5 +45,6 @@
   </table>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/labor.html
+++ b/src/main/resources/templates/labor.html
@@ -48,5 +48,6 @@
   </table>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/nutrition.html
+++ b/src/main/resources/templates/nutrition.html
@@ -110,5 +110,6 @@
   </div>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/production.html
+++ b/src/main/resources/templates/production.html
@@ -31,5 +31,6 @@
   </table>
 </div>
 <div th:replace="~{fragments/scripts :: farm-scripts}"></div>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate a basic WeatherService that calls Open‑Meteo
- expose `/weather` endpoint secured by crop ownership
- show weather info in a new footer fragment via JS
- load new weather script in base scripts and cache it offline
- update templates to include footer on all pages

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686ebf1f5e608323bf1ec280a40410ba