### PR TITLE
Implement engineer-producer relationships

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/controller/EngineerController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/EngineerController.java
@@ -12,11 +12,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpServerErrorException;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +54,20 @@ public class EngineerController {
         validateEngineer(token);
         engineerService.addClient(token, producerId);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/producers/{producerId}")
+    public ResponseEntity<Void> removeProducer(@PathVariable Long producerId,
+                                               @RequestHeader("Authorization") String token) {
+        validateEngineer(token);
+        engineerService.removeClient(token, producerId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/all-producers")
+    public ResponseEntity<List<UserEntity>> allProducers(@RequestHeader("Authorization") String token) {
+        validateEngineer(token);
+        return ResponseEntity.ok(engineerService.getAllProducers());
     }
 
     @GetMapping("/crops")

--- a/src/main/java/com/meztlitech/agrobitacora/controller/EngineerController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/EngineerController.java
@@ -67,7 +67,7 @@ public class EngineerController {
     @GetMapping("/all-producers")
     public ResponseEntity<List<UserEntity>> allProducers(@RequestHeader("Authorization") String token) {
         validateEngineer(token);
-        return ResponseEntity.ok(engineerService.getAllProducers());
+        return ResponseEntity.ok(engineerService.getAvailableProducers(token));
     }
 
     @GetMapping("/crops")

--- a/src/main/java/com/meztlitech/agrobitacora/controller/EngineerController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/EngineerController.java
@@ -49,7 +49,15 @@ public class EngineerController {
     @GetMapping("/producers")
     public ResponseEntity<List<UserEntity>> producers(@RequestHeader("Authorization") String token) {
         validateEngineer(token);
-        return ResponseEntity.ok(engineerService.getProducers());
+        return ResponseEntity.ok(engineerService.getProducers(token));
+    }
+
+    @PostMapping("/producers/{producerId}")
+    public ResponseEntity<Void> addProducer(@PathVariable Long producerId,
+                                            @RequestHeader("Authorization") String token) {
+        validateEngineer(token);
+        engineerService.addClient(token, producerId);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/crops")

--- a/src/main/java/com/meztlitech/agrobitacora/controller/ProducerController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/ProducerController.java
@@ -66,4 +66,15 @@ public class ProducerController {
         engineerService.removeEngineer(token, engineerId);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/engineers/{engineerId}/rating")
+    public ResponseEntity<Void> rateEngineer(@PathVariable Long engineerId,
+                                             @RequestHeader("Authorization") String token,
+                                             @RequestBody Map<String, Object> body) {
+        validateProducer(token);
+        int rating = Integer.parseInt(body.getOrDefault("rating", 0).toString());
+        String review = body.getOrDefault("review", "").toString();
+        engineerService.rateEngineer(token, engineerId, rating, review);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/meztlitech/agrobitacora/controller/ProducerController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/ProducerController.java
@@ -42,7 +42,7 @@ public class ProducerController {
     @GetMapping("/engineers")
     public ResponseEntity<List<UserEntity>> engineers(@RequestHeader("Authorization") String token) {
         validateProducer(token);
-        return ResponseEntity.ok(engineerService.getAllEngineers());
+        return ResponseEntity.ok(engineerService.getAvailableEngineers(token));
     }
 
     @GetMapping("/my-engineers")

--- a/src/main/java/com/meztlitech/agrobitacora/controller/ProducerController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/ProducerController.java
@@ -58,4 +58,12 @@ public class ProducerController {
         engineerService.addEngineer(token, engineerId);
         return ResponseEntity.ok().build();
     }
+
+    @DeleteMapping("/engineers/{engineerId}")
+    public ResponseEntity<Void> removeEngineer(@PathVariable Long engineerId,
+                                               @RequestHeader("Authorization") String token) {
+        validateProducer(token);
+        engineerService.removeEngineer(token, engineerId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/meztlitech/agrobitacora/controller/ProducerController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/ProducerController.java
@@ -1,0 +1,61 @@
+package com.meztlitech.agrobitacora.controller;
+
+import com.meztlitech.agrobitacora.entity.UserEntity;
+import com.meztlitech.agrobitacora.service.EngineerService;
+import com.meztlitech.agrobitacora.service.JwtService;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpServerErrorException;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/producer")
+@RequiredArgsConstructor
+@Log4j2
+public class ProducerController {
+
+    private final EngineerService engineerService;
+    private final JwtService jwtService;
+    private static final String ROLE_PRODUCTOR = "Productor";
+
+    private void validateProducer(String token) {
+        Claims claims = jwtService.decodeToken(token);
+        Object roleObj = claims.get("role");
+        String role = null;
+        if (roleObj instanceof Map) {
+            Object name = ((Map<?,?>) roleObj).get("name");
+            if (name != null) role = name.toString();
+        } else if (roleObj != null) {
+            role = roleObj.toString();
+        }
+        if (!ROLE_PRODUCTOR.equals(role)) {
+            throw new HttpServerErrorException(HttpStatus.FORBIDDEN, "Access denied");
+        }
+    }
+
+    @GetMapping("/engineers")
+    public ResponseEntity<List<UserEntity>> engineers(@RequestHeader("Authorization") String token) {
+        validateProducer(token);
+        return ResponseEntity.ok(engineerService.getAllEngineers());
+    }
+
+    @GetMapping("/my-engineers")
+    public ResponseEntity<List<UserEntity>> myEngineers(@RequestHeader("Authorization") String token) {
+        validateProducer(token);
+        return ResponseEntity.ok(engineerService.getEngineers(token));
+    }
+
+    @PostMapping("/engineers/{engineerId}")
+    public ResponseEntity<Void> addEngineer(@PathVariable Long engineerId,
+                                            @RequestHeader("Authorization") String token) {
+        validateProducer(token);
+        engineerService.addEngineer(token, engineerId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/meztlitech/agrobitacora/controller/ViewController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/ViewController.java
@@ -56,6 +56,11 @@ public class ViewController {
         return "production";
     }
 
+    @GetMapping("/association")
+    public String association() {
+        return "association";
+    }
+
     @GetMapping("/balance")
     public String balance() {
         return "balance";

--- a/src/main/java/com/meztlitech/agrobitacora/entity/EngineerProducerEntity.java
+++ b/src/main/java/com/meztlitech/agrobitacora/entity/EngineerProducerEntity.java
@@ -1,0 +1,29 @@
+package com.meztlitech.agrobitacora.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "engineer_producers",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"engineer_id", "producer_id"}))
+@Data
+public class EngineerProducerEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "engineer_id", nullable = false)
+    private UserEntity engineer;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "producer_id", nullable = false)
+    private UserEntity producer;
+}

--- a/src/main/java/com/meztlitech/agrobitacora/entity/EngineerReviewEntity.java
+++ b/src/main/java/com/meztlitech/agrobitacora/entity/EngineerReviewEntity.java
@@ -1,0 +1,34 @@
+package com.meztlitech.agrobitacora.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "engineer_reviews", uniqueConstraints = @UniqueConstraint(columnNames = {"engineer_id", "producer_id"}))
+@Data
+public class EngineerReviewEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "engineer_id", nullable = false)
+    private UserEntity engineer;
+
+    @ManyToOne(fetch = FetchType.EAGER, optional = false)
+    @JoinColumn(name = "producer_id", nullable = false)
+    private UserEntity producer;
+
+    @Column(name = "rating")
+    private Integer rating;
+
+    @Column(name = "review", length = 1000)
+    private String review;
+}

--- a/src/main/java/com/meztlitech/agrobitacora/entity/UserEntity.java
+++ b/src/main/java/com/meztlitech/agrobitacora/entity/UserEntity.java
@@ -53,6 +53,9 @@ public class UserEntity implements UserDetails {
     @JsonIgnore
     private RoleEntity role;
 
+    @Transient
+    private Double ranking;
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<SimpleGrantedAuthority> authorities = new HashSet<>();

--- a/src/main/java/com/meztlitech/agrobitacora/repository/EngineerProducerRepository.java
+++ b/src/main/java/com/meztlitech/agrobitacora/repository/EngineerProducerRepository.java
@@ -1,0 +1,23 @@
+package com.meztlitech.agrobitacora.repository;
+
+import com.meztlitech.agrobitacora.entity.EngineerProducerEntity;
+import com.meztlitech.agrobitacora.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface EngineerProducerRepository extends JpaRepository<EngineerProducerEntity, Long> {
+
+    @Query("SELECT ep.producer FROM EngineerProducerEntity ep WHERE ep.engineer.id = :engineerId")
+    List<UserEntity> findProducersByEngineerId(Long engineerId);
+
+    @Query("SELECT ep.engineer FROM EngineerProducerEntity ep WHERE ep.producer.id = :producerId")
+    List<UserEntity> findEngineersByProducerId(Long producerId);
+
+    void deleteByEngineerIdAndProducerId(Long engineerId, Long producerId);
+
+    boolean existsByEngineerIdAndProducerId(Long engineerId, Long producerId);
+}

--- a/src/main/java/com/meztlitech/agrobitacora/repository/EngineerReviewRepository.java
+++ b/src/main/java/com/meztlitech/agrobitacora/repository/EngineerReviewRepository.java
@@ -1,0 +1,17 @@
+package com.meztlitech.agrobitacora.repository;
+
+import com.meztlitech.agrobitacora.entity.EngineerReviewEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EngineerReviewRepository extends JpaRepository<EngineerReviewEntity, Long> {
+
+    @Query("SELECT AVG(r.rating) FROM EngineerReviewEntity r WHERE r.engineer.id = :engineerId")
+    Double averageRatingByEngineerId(Long engineerId);
+
+    Optional<EngineerReviewEntity> findByEngineerIdAndProducerId(Long engineerId, Long producerId);
+}

--- a/src/main/java/com/meztlitech/agrobitacora/service/EngineerService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/EngineerService.java
@@ -36,6 +36,10 @@ public class EngineerService {
         return engineerProducerRepository.findProducersByEngineerId(engineerId);
     }
 
+    public List<UserEntity> getAllProducers() {
+        return userRepository.findByRoleName(ROLE_PRODUCTOR);
+    }
+
     public List<UserEntity> getEngineers(String token) {
         Claims claims = jwtService.decodeToken(token);
         Long producerId = Long.parseLong(claims.get("id").toString());
@@ -58,6 +62,12 @@ public class EngineerService {
         }
     }
 
+    public void removeClient(String token, Long producerId) {
+        Claims claims = jwtService.decodeToken(token);
+        Long engineerId = Long.parseLong(claims.get("id").toString());
+        engineerProducerRepository.deleteByEngineerIdAndProducerId(engineerId, producerId);
+    }
+
     public void addEngineer(String token, Long engineerId) {
         Claims claims = jwtService.decodeToken(token);
         Long producerId = Long.parseLong(claims.get("id").toString());
@@ -68,6 +78,12 @@ public class EngineerService {
                     .build();
             engineerProducerRepository.save(ep);
         }
+    }
+
+    public void removeEngineer(String token, Long engineerId) {
+        Claims claims = jwtService.decodeToken(token);
+        Long producerId = Long.parseLong(claims.get("id").toString());
+        engineerProducerRepository.deleteByEngineerIdAndProducerId(engineerId, producerId);
     }
 
     public Page<CropEntity> getCrops(Long producerId, CropFilter filter) {

--- a/src/main/java/com/meztlitech/agrobitacora/service/EngineerService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/EngineerService.java
@@ -40,6 +40,15 @@ public class EngineerService {
         return userRepository.findByRoleName(ROLE_PRODUCTOR);
     }
 
+    public List<UserEntity> getAvailableProducers(String token) {
+        Claims claims = jwtService.decodeToken(token);
+        Long engineerId = Long.parseLong(claims.get("id").toString());
+        List<UserEntity> all = getAllProducers();
+        List<UserEntity> mine = engineerProducerRepository.findProducersByEngineerId(engineerId);
+        all.removeAll(mine);
+        return all;
+    }
+
     public List<UserEntity> getEngineers(String token) {
         Claims claims = jwtService.decodeToken(token);
         Long producerId = Long.parseLong(claims.get("id").toString());
@@ -48,6 +57,15 @@ public class EngineerService {
 
     public List<UserEntity> getAllEngineers() {
         return userRepository.findByRoleName("Ingeniero");
+    }
+
+    public List<UserEntity> getAvailableEngineers(String token) {
+        Claims claims = jwtService.decodeToken(token);
+        Long producerId = Long.parseLong(claims.get("id").toString());
+        List<UserEntity> all = getAllEngineers();
+        List<UserEntity> mine = engineerProducerRepository.findEngineersByProducerId(producerId);
+        all.removeAll(mine);
+        return all;
     }
 
     public void addClient(String token, Long producerId) {

--- a/src/main/java/com/meztlitech/agrobitacora/service/EngineerService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/EngineerService.java
@@ -5,6 +5,10 @@ import com.meztlitech.agrobitacora.entity.CropEntity;
 import com.meztlitech.agrobitacora.entity.UserEntity;
 import com.meztlitech.agrobitacora.repository.CropRepository;
 import com.meztlitech.agrobitacora.repository.UserRepository;
+import com.meztlitech.agrobitacora.repository.EngineerProducerRepository;
+import com.meztlitech.agrobitacora.service.JwtService;
+import com.meztlitech.agrobitacora.entity.EngineerProducerEntity;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
@@ -21,11 +25,49 @@ public class EngineerService {
 
     private final UserRepository userRepository;
     private final CropRepository cropRepository;
+    private final EngineerProducerRepository engineerProducerRepository;
+    private final JwtService jwtService;
 
     private static final String ROLE_PRODUCTOR = "Productor";
 
-    public List<UserEntity> getProducers() {
-        return userRepository.findByRoleName(ROLE_PRODUCTOR);
+    public List<UserEntity> getProducers(String token) {
+        Claims claims = jwtService.decodeToken(token);
+        Long engineerId = Long.parseLong(claims.get("id").toString());
+        return engineerProducerRepository.findProducersByEngineerId(engineerId);
+    }
+
+    public List<UserEntity> getEngineers(String token) {
+        Claims claims = jwtService.decodeToken(token);
+        Long producerId = Long.parseLong(claims.get("id").toString());
+        return engineerProducerRepository.findEngineersByProducerId(producerId);
+    }
+
+    public List<UserEntity> getAllEngineers() {
+        return userRepository.findByRoleName("Ingeniero");
+    }
+
+    public void addClient(String token, Long producerId) {
+        Claims claims = jwtService.decodeToken(token);
+        Long engineerId = Long.parseLong(claims.get("id").toString());
+        if (!engineerProducerRepository.existsByEngineerIdAndProducerId(engineerId, producerId)) {
+            EngineerProducerEntity ep = EngineerProducerEntity.builder()
+                    .engineer(userRepository.findById(engineerId).orElseThrow())
+                    .producer(userRepository.findById(producerId).orElseThrow())
+                    .build();
+            engineerProducerRepository.save(ep);
+        }
+    }
+
+    public void addEngineer(String token, Long engineerId) {
+        Claims claims = jwtService.decodeToken(token);
+        Long producerId = Long.parseLong(claims.get("id").toString());
+        if (!engineerProducerRepository.existsByEngineerIdAndProducerId(engineerId, producerId)) {
+            EngineerProducerEntity ep = EngineerProducerEntity.builder()
+                    .engineer(userRepository.findById(engineerId).orElseThrow())
+                    .producer(userRepository.findById(producerId).orElseThrow())
+                    .build();
+            engineerProducerRepository.save(ep);
+        }
     }
 
     public Page<CropEntity> getCrops(Long producerId, CropFilter filter) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -41,3 +41,13 @@ CREATE TYPE public.irrigation_type AS ENUM (
     'GRAVEDAD',
     'HIDROPONICO'
 );
+
+CREATE TABLE public.engineer_producers (
+    id int8 NOT NULL,
+    engineer_id int8 NOT NULL,
+    producer_id int8 NOT NULL,
+    CONSTRAINT engineer_producers_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_engineer FOREIGN KEY (engineer_id) REFERENCES public.users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_producer FOREIGN KEY (producer_id) REFERENCES public.users(id) ON DELETE CASCADE,
+    CONSTRAINT uk_engineer_producer UNIQUE (engineer_id, producer_id)
+);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -51,3 +51,15 @@ CREATE TABLE public.engineer_producers (
     CONSTRAINT fk_producer FOREIGN KEY (producer_id) REFERENCES public.users(id) ON DELETE CASCADE,
     CONSTRAINT uk_engineer_producer UNIQUE (engineer_id, producer_id)
 );
+CREATE TABLE public.engineer_reviews (
+    id int8 NOT NULL,
+    engineer_id int8 NOT NULL,
+    producer_id int8 NOT NULL,
+    rating int4 NULL,
+    review varchar(1000) NULL,
+    CONSTRAINT engineer_reviews_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_review_engineer FOREIGN KEY (engineer_id) REFERENCES public.users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_review_producer FOREIGN KEY (producer_id) REFERENCES public.users(id) ON DELETE CASCADE,
+    CONSTRAINT uk_review UNIQUE (engineer_id, producer_id)
+);
+

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -52,3 +52,11 @@ bill.kind.OTHER=Otros
 
 weather.info=Clima
 weather.title=Condiciones climáticas
+association.title=Asociaciones
+association.available.engineers=Ingenieros disponibles
+association.my.engineers=Mis ingenieros
+association.available.producers=Productores disponibles
+association.my.producers=Mis productores
+association.add=Agregar
+association.remove=Quitar
+menu.association=Asociaciones

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -59,4 +59,7 @@ association.available.producers=Productores disponibles
 association.my.producers=Mis productores
 association.add=Agregar
 association.remove=Quitar
+association.rate=Calificar
+association.rating.prompt=Calificación (1-5)
+association.review.prompt=Reseña
 menu.association=Asociaciones

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -59,4 +59,7 @@ association.available.producers=Available producers
 association.my.producers=My producers
 association.add=Add
 association.remove=Remove
+association.rate=Rate
+association.rating.prompt=Rating (1-5)
+association.review.prompt=Review
 menu.association=Associations

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -52,3 +52,11 @@ bill.kind.OTHER=Other
 
 weather.info=Weather
 weather.title=Weather Conditions
+association.title=Associations
+association.available.engineers=Available engineers
+association.my.engineers=My engineers
+association.available.producers=Available producers
+association.my.producers=My producers
+association.add=Add
+association.remove=Remove
+menu.association=Associations

--- a/src/main/resources/static/js/association.js
+++ b/src/main/resources/static/js/association.js
@@ -1,0 +1,136 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const role = App.getRole();
+    if (role === 'Productor') {
+        initProducer();
+    } else if (role === 'Ingeniero') {
+        initEngineer();
+    }
+});
+
+async function initProducer() {
+    const container = document.getElementById('association-content');
+    container.innerHTML = `
+    <div class="row">
+      <div class="col-md-6">
+        <h5 class="mb-3" data-i18n="association.available.engineers">Ingenieros disponibles</h5>
+        <table id="all-engineers" class="table table-striped">
+          <thead><tr><th>ID</th><th>Nombre</th><th></th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <div class="col-md-6">
+        <h5 class="mb-3" data-i18n="association.my.engineers">Mis ingenieros</h5>
+        <table id="my-engineers" class="table table-striped">
+          <thead><tr><th>ID</th><th>Nombre</th><th></th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>`;
+    await loadAllEngineers();
+    await loadMyEngineers();
+}
+
+async function initEngineer() {
+    const container = document.getElementById('association-content');
+    container.innerHTML = `
+    <div class="row">
+      <div class="col-md-6">
+        <h5 class="mb-3" data-i18n="association.available.producers">Productores disponibles</h5>
+        <table id="all-producers" class="table table-striped">
+          <thead><tr><th>ID</th><th>Nombre</th><th></th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <div class="col-md-6">
+        <h5 class="mb-3" data-i18n="association.my.producers">Mis productores</h5>
+        <table id="my-producers" class="table table-striped">
+          <thead><tr><th>ID</th><th>Nombre</th><th></th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>`;
+    await loadAllProducers();
+    await loadMyProducers();
+}
+
+async function loadAllEngineers() {
+    const res = await fetch('/producer/engineers');
+    if (!res.ok) return;
+    const data = await res.json();
+    const tbody = document.querySelector('#all-engineers tbody');
+    tbody.innerHTML = '';
+    data.forEach(e => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${e.id}</td><td>${e.name}</td><td><button class="btn btn-sm btn-primary" data-id="${e.id}" data-action="add-engineer">${i18n('association.add')}</button></td>`;
+        tbody.appendChild(tr);
+    });
+    tbody.querySelectorAll('button[data-action="add-engineer"]').forEach(btn => {
+        btn.addEventListener('click', async () => {
+            await fetch(`/producer/engineers/${btn.dataset.id}`, { method: 'POST' });
+            loadMyEngineers();
+        });
+    });
+}
+
+async function loadMyEngineers() {
+    const res = await fetch('/producer/my-engineers');
+    if (!res.ok) return;
+    const data = await res.json();
+    const tbody = document.querySelector('#my-engineers tbody');
+    tbody.innerHTML = '';
+    data.forEach(e => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${e.id}</td><td>${e.name}</td><td><button class="btn btn-sm btn-danger" data-id="${e.id}" data-action="del-engineer">${i18n('association.remove')}</button></td>`;
+        tbody.appendChild(tr);
+    });
+    tbody.querySelectorAll('button[data-action="del-engineer"]').forEach(btn => {
+        btn.addEventListener('click', async () => {
+            await fetch(`/producer/engineers/${btn.dataset.id}`, { method: 'DELETE' });
+            loadMyEngineers();
+        });
+    });
+}
+
+async function loadAllProducers() {
+    const res = await fetch('/engineer/all-producers');
+    if (!res.ok) return;
+    const data = await res.json();
+    const tbody = document.querySelector('#all-producers tbody');
+    tbody.innerHTML = '';
+    data.forEach(p => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${p.id}</td><td>${p.name}</td><td><button class="btn btn-sm btn-primary" data-id="${p.id}" data-action="add-producer">${i18n('association.add')}</button></td>`;
+        tbody.appendChild(tr);
+    });
+    tbody.querySelectorAll('button[data-action="add-producer"]').forEach(btn => {
+        btn.addEventListener('click', async () => {
+            await fetch(`/engineer/producers/${btn.dataset.id}`, { method: 'POST' });
+            loadMyProducers();
+        });
+    });
+}
+
+async function loadMyProducers() {
+    const res = await fetch('/engineer/producers');
+    if (!res.ok) return;
+    const data = await res.json();
+    const tbody = document.querySelector('#my-producers tbody');
+    tbody.innerHTML = '';
+    data.forEach(p => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${p.id}</td><td>${p.name}</td><td><button class="btn btn-sm btn-danger" data-id="${p.id}" data-action="del-producer">${i18n('association.remove')}</button></td>`;
+        tbody.appendChild(tr);
+    });
+    tbody.querySelectorAll('button[data-action="del-producer"]').forEach(btn => {
+        btn.addEventListener('click', async () => {
+            await fetch(`/engineer/producers/${btn.dataset.id}`, { method: 'DELETE' });
+            loadMyProducers();
+        });
+    });
+}
+
+function i18n(key) {
+    if (key === 'association.add') return document.getElementById('assoc-add').textContent.trim();
+    if (key === 'association.remove') return document.getElementById('assoc-remove').textContent.trim();
+    return key;
+}

--- a/src/main/resources/static/js/association.js
+++ b/src/main/resources/static/js/association.js
@@ -73,6 +73,7 @@ async function loadAllEngineers() {
                 headers: { Authorization: 'Bearer ' + App.getToken() }
             });
             loadMyEngineers();
+            loadAllEngineers();
         });
     });
 }
@@ -97,6 +98,7 @@ async function loadMyEngineers() {
                 headers: { Authorization: 'Bearer ' + App.getToken() }
             });
             loadMyEngineers();
+            loadAllEngineers();
         });
     });
 }
@@ -121,6 +123,7 @@ async function loadAllProducers() {
                 headers: { Authorization: 'Bearer ' + App.getToken() }
             });
             loadMyProducers();
+            loadAllProducers();
         });
     });
 }
@@ -145,6 +148,7 @@ async function loadMyProducers() {
                 headers: { Authorization: 'Bearer ' + App.getToken() }
             });
             loadMyProducers();
+            loadAllProducers();
         });
     });
 }

--- a/src/main/resources/static/js/association.js
+++ b/src/main/resources/static/js/association.js
@@ -54,7 +54,9 @@ async function initEngineer() {
 }
 
 async function loadAllEngineers() {
-    const res = await fetch('/producer/engineers');
+    const res = await fetch('/producer/engineers', {
+        headers: { Authorization: 'Bearer ' + App.getToken() }
+    });
     if (!res.ok) return;
     const data = await res.json();
     const tbody = document.querySelector('#all-engineers tbody');
@@ -66,14 +68,19 @@ async function loadAllEngineers() {
     });
     tbody.querySelectorAll('button[data-action="add-engineer"]').forEach(btn => {
         btn.addEventListener('click', async () => {
-            await fetch(`/producer/engineers/${btn.dataset.id}`, { method: 'POST' });
+            await fetch(`/producer/engineers/${btn.dataset.id}`, {
+                method: 'POST',
+                headers: { Authorization: 'Bearer ' + App.getToken() }
+            });
             loadMyEngineers();
         });
     });
 }
 
 async function loadMyEngineers() {
-    const res = await fetch('/producer/my-engineers');
+    const res = await fetch('/producer/my-engineers', {
+        headers: { Authorization: 'Bearer ' + App.getToken() }
+    });
     if (!res.ok) return;
     const data = await res.json();
     const tbody = document.querySelector('#my-engineers tbody');
@@ -85,14 +92,19 @@ async function loadMyEngineers() {
     });
     tbody.querySelectorAll('button[data-action="del-engineer"]').forEach(btn => {
         btn.addEventListener('click', async () => {
-            await fetch(`/producer/engineers/${btn.dataset.id}`, { method: 'DELETE' });
+            await fetch(`/producer/engineers/${btn.dataset.id}`, {
+                method: 'DELETE',
+                headers: { Authorization: 'Bearer ' + App.getToken() }
+            });
             loadMyEngineers();
         });
     });
 }
 
 async function loadAllProducers() {
-    const res = await fetch('/engineer/all-producers');
+    const res = await fetch('/engineer/all-producers', {
+        headers: { Authorization: 'Bearer ' + App.getToken() }
+    });
     if (!res.ok) return;
     const data = await res.json();
     const tbody = document.querySelector('#all-producers tbody');
@@ -104,14 +116,19 @@ async function loadAllProducers() {
     });
     tbody.querySelectorAll('button[data-action="add-producer"]').forEach(btn => {
         btn.addEventListener('click', async () => {
-            await fetch(`/engineer/producers/${btn.dataset.id}`, { method: 'POST' });
+            await fetch(`/engineer/producers/${btn.dataset.id}`, {
+                method: 'POST',
+                headers: { Authorization: 'Bearer ' + App.getToken() }
+            });
             loadMyProducers();
         });
     });
 }
 
 async function loadMyProducers() {
-    const res = await fetch('/engineer/producers');
+    const res = await fetch('/engineer/producers', {
+        headers: { Authorization: 'Bearer ' + App.getToken() }
+    });
     if (!res.ok) return;
     const data = await res.json();
     const tbody = document.querySelector('#my-producers tbody');
@@ -123,7 +140,10 @@ async function loadMyProducers() {
     });
     tbody.querySelectorAll('button[data-action="del-producer"]').forEach(btn => {
         btn.addEventListener('click', async () => {
-            await fetch(`/engineer/producers/${btn.dataset.id}`, { method: 'DELETE' });
+            await fetch(`/engineer/producers/${btn.dataset.id}`, {
+                method: 'DELETE',
+                headers: { Authorization: 'Bearer ' + App.getToken() }
+            });
             loadMyProducers();
         });
     });

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -517,7 +517,7 @@
 
         function showMenus() {
             const role = App.getRole();
-            const all = ['#menu-bill','#menu-crop','#menu-fumigation','#menu-irrigation','#menu-labor','#menu-nutrition','#menu-production','#menu-balance'];
+            const all = ['#menu-association','#menu-bill','#menu-crop','#menu-fumigation','#menu-irrigation','#menu-labor','#menu-nutrition','#menu-production','#menu-balance'];
             all.forEach(sel => $(sel).addClass('d-none'));
             $('#admin-menu').addClass('d-none');
             if (role === 'Admin') {
@@ -529,7 +529,7 @@
             }
             let allow = all;
             if (role === 'Ingeniero') {
-                allow = ['#menu-fumigation','#menu-nutrition'];
+                allow = ['#menu-association','#menu-fumigation','#menu-nutrition'];
             }
             const hasCrop = !!localStorage.getItem('cropId');
             if (!hasCrop && App.getToken()) {

--- a/src/main/resources/templates/association.html
+++ b/src/main/resources/templates/association.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head(#{association.title})}"></head>
+<body>
+<nav th:replace="~{fragments/nav :: nav}"></nav>
+<div class="container mt-4">
+  <h1 class="mb-4">
+    <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+    <span th:text="#{association.title}"></span>
+  </h1>
+  <span id="assoc-add" th:text="#{association.add}" class="d-none"></span>
+  <span id="assoc-remove" th:text="#{association.remove}" class="d-none"></span>
+  <div id="association-content"></div>
+</div>
+<div th:replace="~{fragments/scripts :: base-scripts}"></div>
+<script th:src="@{/js/association.js}" defer></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/association.html
+++ b/src/main/resources/templates/association.html
@@ -10,6 +10,9 @@
   </h1>
   <span id="assoc-add" th:text="#{association.add}" class="d-none"></span>
   <span id="assoc-remove" th:text="#{association.remove}" class="d-none"></span>
+  <span id="assoc-rate" th:text="#{association.rate}" class="d-none"></span>
+  <span id="assoc-rating-prompt" th:text="#{association.rating.prompt}" class="d-none"></span>
+  <span id="assoc-review-prompt" th:text="#{association.review.prompt}" class="d-none"></span>
   <div id="association-content"></div>
 </div>
 <div th:replace="~{fragments/scripts :: base-scripts}"></div>

--- a/src/main/resources/templates/fragments/nav.html
+++ b/src/main/resources/templates/fragments/nav.html
@@ -56,6 +56,7 @@
       <a id="menu-production" class="list-group-item list-group-item-action menu-item d-none" th:href="@{/production}" th:text="#{home.production}">Production</a>
       <a id="menu-bill" class="list-group-item list-group-item-action menu-item d-none" th:href="@{/bill}" th:text="#{home.bills}">Bills</a>
       <a id="menu-balance" class="list-group-item list-group-item-action menu-item d-none" th:href="@{/balance}">Balance</a>
+      <a id="menu-association" class="list-group-item list-group-item-action menu-item d-none" th:href="@{/association}" th:text="#{menu.association}">Associations</a>
       <a id="admin-menu" class="list-group-item list-group-item-action d-none" th:href="@{/admin}" th:text="#{admin.title}">Admin</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add `EngineerProducerEntity` and repository
- extend `EngineerService` for linking engineers and producers
- create `ProducerController` for producers to manage engineers
- update `EngineerController` for client management
- create table for engineer_producers in `data.sql`

## Testing
- `./mvnw -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68769c9bd7b083239a2712c678c9c57f