### PR TITLE
Add weather history

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
@@ -2,19 +2,15 @@ package com.meztlitech.agrobitacora.controller;
 
 import com.meztlitech.agrobitacora.dto.WeatherRecordDto;
 import com.meztlitech.agrobitacora.entity.CropEntity;
-import com.meztlitech.agrobitacora.entity.WeatherRecordEntity;
 import com.meztlitech.agrobitacora.repository.CropRepository;
 import com.meztlitech.agrobitacora.service.WeatherService;
 import com.meztlitech.agrobitacora.util.CropUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/weather")
@@ -32,23 +28,13 @@ public class WeatherController {
         cropUtil.validateCropByUser(token, cropId);
         CropEntity crop = cropRepository.findById(cropId).orElseThrow();
         WeatherService.WeatherInfo info = weatherService.getWeather(
-                crop.getLatitud(), crop.getLongitud(), cropId);
+                crop.getLatitud(), crop.getLongitud());
         if (info == null) {
             return ResponseEntity.noContent().build();
         }
         info.setLocation(crop.getLocation());
         weatherService.mergeWithRecord(info, cropId);
         return ResponseEntity.ok(info);
-    }
-
-    @PostMapping
-    public ResponseEntity<WeatherRecordEntity> saveRecord(
-            @Valid @RequestBody WeatherRecordDto dto,
-            @RequestHeader("cropId") Long cropId,
-            @RequestHeader("Authorization") String token) {
-        cropUtil.validateCropByUser(token, cropId);
-        WeatherRecordEntity saved = weatherService.saveRecord(cropId, dto);
-        return ResponseEntity.ok(saved);
     }
 
     @GetMapping("/history")

--- a/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
@@ -50,4 +50,12 @@ public class WeatherController {
         WeatherRecordEntity saved = weatherService.saveRecord(cropId, dto);
         return ResponseEntity.ok(saved);
     }
+
+    @GetMapping("/history")
+    public ResponseEntity<java.util.List<WeatherRecordEntity>> history(
+            @RequestHeader("cropId") Long cropId,
+            @RequestHeader("Authorization") String token) {
+        cropUtil.validateCropByUser(token, cropId);
+        return ResponseEntity.ok(weatherService.getHistory(cropId));
+    }
 }

--- a/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/WeatherController.java
@@ -52,10 +52,11 @@ public class WeatherController {
     }
 
     @GetMapping("/history")
-    public ResponseEntity<java.util.List<WeatherRecordEntity>> history(
+    public ResponseEntity<java.util.List<WeatherRecordDto>> history(
             @RequestHeader("cropId") Long cropId,
             @RequestHeader("Authorization") String token) {
         cropUtil.validateCropByUser(token, cropId);
-        return ResponseEntity.ok(weatherService.getHistory(cropId));
+        CropEntity crop = cropRepository.findById(cropId).orElseThrow();
+        return ResponseEntity.ok(weatherService.getHistory(crop.getLatitud(), crop.getLongitud()));
     }
 }

--- a/src/main/java/com/meztlitech/agrobitacora/repository/WeatherRecordRepository.java
+++ b/src/main/java/com/meztlitech/agrobitacora/repository/WeatherRecordRepository.java
@@ -10,6 +10,4 @@ import java.util.Optional;
 @Repository
 public interface WeatherRecordRepository extends JpaRepository<WeatherRecordEntity, Long> {
     Optional<WeatherRecordEntity> findTopByCropIdAndDate(Long cropId, LocalDate date);
-
-    java.util.List<WeatherRecordEntity> findTop7ByCropIdOrderByDateDesc(Long cropId);
 }

--- a/src/main/java/com/meztlitech/agrobitacora/repository/WeatherRecordRepository.java
+++ b/src/main/java/com/meztlitech/agrobitacora/repository/WeatherRecordRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface WeatherRecordRepository extends JpaRepository<WeatherRecordEntity, Long> {
     Optional<WeatherRecordEntity> findTopByCropIdAndDate(Long cropId, LocalDate date);
+
+    java.util.List<WeatherRecordEntity> findTop7ByCropIdOrderByDateDesc(Long cropId);
 }

--- a/src/main/java/com/meztlitech/agrobitacora/service/WeatherService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/WeatherService.java
@@ -1,9 +1,6 @@
 package com.meztlitech.agrobitacora.service;
 
 import com.meztlitech.agrobitacora.dto.WeatherRecordDto;
-import com.meztlitech.agrobitacora.entity.CropEntity;
-import com.meztlitech.agrobitacora.entity.WeatherRecordEntity;
-import com.meztlitech.agrobitacora.repository.CropRepository;
 import com.meztlitech.agrobitacora.repository.WeatherRecordRepository;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,9 +21,8 @@ public class WeatherService {
 
     private final RestTemplate restTemplate;
     private final WeatherRecordRepository recordRepository;
-    private final CropRepository cropRepository;
 
-    public WeatherInfo getWeather(double latitude, double longitude, Long cropId) {
+    public WeatherInfo getWeather(double latitude, double longitude) {
         String url = "https://api.open-meteo.com/v1/forecast?latitude=" + latitude +
                 "&longitude=" + longitude + "&current_weather=true" +
                 "&hourly=relative_humidity_2m,soil_moisture_0_1cm,shortwave_radiation" +
@@ -61,7 +57,6 @@ public class WeatherService {
         } catch (Exception ex) {
             log.error("Error fetching weather", ex);
         }
-        // fallback values when the API cannot be reached
         WeatherInfo info = new WeatherInfo();
         info.setTemperature(20.0);
         return info;
@@ -83,24 +78,6 @@ public class WeatherService {
             return toDouble(list.get(0));
         }
         return null;
-    }
-
-    public WeatherRecordEntity saveRecord(Long cropId, WeatherRecordDto dto) {
-        CropEntity crop = cropRepository.findById(cropId).orElseThrow();
-        WeatherRecordEntity record = recordRepository
-                .findTopByCropIdAndDate(cropId, dto.getDate())
-                .orElse(new WeatherRecordEntity());
-        record.setCrop(crop);
-        record.setDate(dto.getDate());
-        record.setEvapotranspiration(dto.getEvapotranspiration());
-        record.setTemperatureMin(dto.getTemperatureMin());
-        record.setTemperatureMax(dto.getTemperatureMax());
-        record.setPrecipitation(dto.getPrecipitation());
-        record.setWindSpeed(dto.getWindSpeed());
-        record.setRelativeHumidity(dto.getRelativeHumidity());
-        record.setSolarRadiation(dto.getSolarRadiation());
-        record.setSoilHumidity(dto.getSoilHumidity());
-        return recordRepository.save(record);
     }
 
     public java.util.List<WeatherRecordDto> getHistory(double latitude, double longitude) {

--- a/src/main/java/com/meztlitech/agrobitacora/service/WeatherService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/WeatherService.java
@@ -103,6 +103,10 @@ public class WeatherService {
         return recordRepository.save(record);
     }
 
+    public java.util.List<WeatherRecordEntity> getHistory(Long cropId) {
+        return recordRepository.findTop7ByCropIdOrderByDateDesc(cropId);
+    }
+
     public WeatherInfo mergeWithRecord(WeatherInfo info, Long cropId) {
         LocalDate today = LocalDate.now();
         recordRepository.findTopByCropIdAndDate(cropId, today).ifPresent(r -> {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -63,3 +63,7 @@ association.rate=Calificar
 association.rating.prompt=Calificación (1-5)
 association.review.prompt=Reseña
 menu.association=Asociaciones
+weather.history.title=Historial de temperaturas
+weather.date=Fecha
+weather.tmin=Temp. mín (°C)
+weather.tmax=Temp. máx (°C)

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -63,3 +63,7 @@ association.rate=Rate
 association.rating.prompt=Rating (1-5)
 association.review.prompt=Review
 menu.association=Associations
+weather.history.title=Temperature History
+weather.date=Date
+weather.tmin=Min temp (°C)
+weather.tmax=Max temp (°C)

--- a/src/main/resources/static/css/weather.css
+++ b/src/main/resources/static/css/weather.css
@@ -1,0 +1,10 @@
+.chart-container {
+  position: relative;
+  width: 100%;
+  height: 300px;
+}
+@media (max-width: 576px) {
+  .chart-container {
+    height: 200px;
+  }
+}

--- a/src/main/resources/static/js/weather-page.js
+++ b/src/main/resources/static/js/weather-page.js
@@ -23,7 +23,30 @@
         }
     }
 
+    async function loadHistory() {
+        const cropId = localStorage.getItem('cropId');
+        const token = localStorage.getItem('token');
+        if (!cropId || !token) return;
+        try {
+            const res = await fetch('/weather/history', {
+                headers: { cropId, Authorization: 'Bearer ' + token }
+            });
+            if (!res.ok) return;
+            const data = await res.json();
+            const $tbody = $('#history tbody');
+            $tbody.empty();
+            (data || []).forEach(r => {
+                const tmin = r.temperatureMin != null ? r.temperatureMin.toFixed(1) : '';
+                const tmax = r.temperatureMax != null ? r.temperatureMax.toFixed(1) : '';
+                $tbody.append(`<tr><td>${r.date}</td><td>${tmin}</td><td>${tmax}</td></tr>`);
+            });
+        } catch (e) {
+            console.log('weather history error', e);
+        }
+    }
+
     $(function () {
         loadDetails();
+        loadHistory();
     });
 })();

--- a/src/main/resources/static/js/weather-page.js
+++ b/src/main/resources/static/js/weather-page.js
@@ -60,6 +60,7 @@
                 },
                 options: {
                     responsive: true,
+                    maintainAspectRatio: false,
                     scales: { y: { beginAtZero: false } }
                 }
             });

--- a/src/main/resources/static/js/weather-page.js
+++ b/src/main/resources/static/js/weather-page.js
@@ -23,6 +23,8 @@
         }
     }
 
+    let historyChart;
+
     async function loadHistory() {
         const cropId = localStorage.getItem('cropId');
         const token = localStorage.getItem('token');
@@ -33,12 +35,33 @@
             });
             if (!res.ok) return;
             const data = await res.json();
-            const $tbody = $('#history tbody');
-            $tbody.empty();
-            (data || []).forEach(r => {
-                const tmin = r.temperatureMin != null ? r.temperatureMin.toFixed(1) : '';
-                const tmax = r.temperatureMax != null ? r.temperatureMax.toFixed(1) : '';
-                $tbody.append(`<tr><td>${r.date}</td><td>${tmin}</td><td>${tmax}</td></tr>`);
+            const labels = (data || []).map(r => r.date);
+            const tmin = (data || []).map(r => r.temperatureMin);
+            const tmax = (data || []).map(r => r.temperatureMax);
+            const ctx = document.getElementById('historyChart');
+            if (!ctx) return;
+            if (historyChart) historyChart.destroy();
+            historyChart = new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels,
+                    datasets: [
+                        {
+                            label: ctx.dataset.tmin,
+                            backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                            data: tmin
+                        },
+                        {
+                            label: ctx.dataset.tmax,
+                            backgroundColor: 'rgba(255, 99, 132, 0.5)',
+                            data: tmax
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    scales: { y: { beginAtZero: false } }
+                }
             });
         } catch (e) {
             console.log('weather history error', e);

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -8,5 +8,6 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/flatly/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link rel="stylesheet" th:href="@{/css/weather.css}">
     <script src="/js/app.js"></script>
 </head>

--- a/src/main/resources/templates/fragments/scripts.html
+++ b/src/main/resources/templates/fragments/scripts.html
@@ -2,6 +2,7 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script th:src="@{/js/common.js}"></script>
     <script th:src="@{/js/notifications.js}"></script>
     <script th:src="@{/js/pwa.js}"></script>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -21,8 +21,10 @@
       <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">Humedad del suelo (%)</h6><p id="wd-soil" class="card-text"></p></div></div></div>
     </div>
     <h3 class="mt-4" th:text="#{weather.history.title}">Historial de temperaturas</h3>
-    <canvas id="historyChart" class="w-100" height="300"
-            th:attr="data-tmin=#{weather.tmin},data-tmax=#{weather.tmax}"></canvas>
+    <div class="chart-container">
+      <canvas id="historyChart" class="w-100"
+              th:attr="data-tmin=#{weather.tmin},data-tmax=#{weather.tmax}"></canvas>
+    </div>
   </div>
 
   <div th:replace="~{fragments/scripts :: base-scripts}"></div>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -9,7 +9,7 @@
   <h1 class="mb-4">
     <span th:text="#{weather.title}">Weather</span>
   </h1>
-  <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3">
+    <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3">
     <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title" th:text="#{home.crops}">Crop</h6><p id="wd-location" class="card-text"></p></div></div></div>
     <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">ET₀ (mm)</h6><p id="wd-et" class="card-text"></p></div></div></div>
     <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">Temp. mín (°C)</h6><p id="wd-tmin" class="card-text"></p></div></div></div>
@@ -18,12 +18,23 @@
     <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">Viento (km/h)</h6><p id="wd-wind" class="card-text"></p></div></div></div>
     <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">Humedad relativa (%)</h6><p id="wd-rh" class="card-text"></p></div></div></div>
     <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">Radiación (W/m²)</h6><p id="wd-rad" class="card-text"></p></div></div></div>
-    <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">Humedad del suelo (%)</h6><p id="wd-soil" class="card-text"></p></div></div></div>
+      <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">Humedad del suelo (%)</h6><p id="wd-soil" class="card-text"></p></div></div></div>
+    </div>
+    <h3 class="mt-4" th:text="#{weather.history.title}">Historial de temperaturas</h3>
+    <table class="table table-striped" id="history">
+      <thead>
+        <tr>
+          <th th:text="#{weather.date}">Fecha</th>
+          <th th:text="#{weather.tmin}">Temp. mín (°C)</th>
+          <th th:text="#{weather.tmax}">Temp. máx (°C)</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
   </div>
-</div>
 
-<div th:replace="~{fragments/scripts :: base-scripts}"></div>
-<script th:src="@{/js/weather-page.js}" defer></script>
+  <div th:replace="~{fragments/scripts :: base-scripts}"></div>
+  <script th:src="@{/js/weather-page.js}" defer></script>
 <footer th:replace="~{fragments/footer :: footer}"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -21,16 +21,8 @@
       <div class="col"><div class="card text-center"><div class="card-body"><h6 class="card-title">Humedad del suelo (%)</h6><p id="wd-soil" class="card-text"></p></div></div></div>
     </div>
     <h3 class="mt-4" th:text="#{weather.history.title}">Historial de temperaturas</h3>
-    <table class="table table-striped" id="history">
-      <thead>
-        <tr>
-          <th th:text="#{weather.date}">Fecha</th>
-          <th th:text="#{weather.tmin}">Temp. mín (°C)</th>
-          <th th:text="#{weather.tmax}">Temp. máx (°C)</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <canvas id="historyChart" class="w-100" height="300"
+            th:attr="data-tmin=#{weather.tmin},data-tmax=#{weather.tmax}"></canvas>
   </div>
 
   <div th:replace="~{fragments/scripts :: base-scripts}"></div>


### PR DESCRIPTION
## Summary
- show temperature history on the home dashboard
- fetch weather history records from backend
- add `/weather/history` API endpoint
- provide localized labels

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6876cb0f9c6883239ac6b673e84a2ec6