### PR TITLE
Add admin view filter

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/controller/AdminController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/AdminController.java
@@ -62,6 +62,13 @@ public class AdminController {
         return ResponseEntity.ok(adminService.createEngineer(userDto));
     }
 
+    @PostMapping("/admins")
+    public ResponseEntity<UserResponse> createAdmin(@Valid @RequestBody UserDto userDto,
+                                                    @RequestHeader(value = "Authorization") String token) {
+        validateAdmin(token);
+        return ResponseEntity.ok(adminService.createAdmin(userDto));
+    }
+
     @PutMapping("/users/{id}/password")
     public ResponseEntity<ActionStatusResponse> changePassword(@PathVariable Long id,
                                                                @RequestBody UserDto userDto,

--- a/src/main/java/com/meztlitech/agrobitacora/controller/ViewController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/ViewController.java
@@ -1,10 +1,38 @@
 package com.meztlitech.agrobitacora.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.meztlitech.agrobitacora.entity.RoleEntity;
+import com.meztlitech.agrobitacora.service.JwtService;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
 
 @Controller
+@RequiredArgsConstructor
+@Log4j2
 public class ViewController {
+
+    private final JwtService jwtService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String ROLE_ADMIN = "Admin";
+
+    private boolean isAdmin(String token) {
+        if (token == null) {
+            return false;
+        }
+        try {
+            Claims claims = jwtService.decodeToken(token);
+            RoleEntity role = objectMapper.convertValue(claims.get("role"), RoleEntity.class);
+            return ROLE_ADMIN.equals(role.getName());
+        } catch (Exception e) {
+            log.warn("Failed to validate admin token", e);
+            return false;
+        }
+    }
 
     @GetMapping("/")
     public String index() {
@@ -67,17 +95,34 @@ public class ViewController {
     }
 
     @GetMapping("/admin")
-    public String admin() {
+    public String admin(@RequestHeader(value = "Authorization", required = false) String token) {
+        if (!isAdmin(token)) {
+            return "redirect:/home";
+        }
         return "admin";
     }
 
     @GetMapping("/admin/users")
-    public String adminUsers() {
+    public String adminUsers(@RequestHeader(value = "Authorization", required = false) String token) {
+        if (!isAdmin(token)) {
+            return "redirect:/home";
+        }
         return "admin-users";
     }
 
     @GetMapping("/admin/engineers")
-    public String adminEngineers() {
+    public String adminEngineers(@RequestHeader(value = "Authorization", required = false) String token) {
+        if (!isAdmin(token)) {
+            return "redirect:/home";
+        }
         return "admin-engineers";
+    }
+
+    @GetMapping("/admin/admins")
+    public String adminAdmins(@RequestHeader(value = "Authorization", required = false) String token) {
+        if (!isAdmin(token)) {
+            return "redirect:/home";
+        }
+        return "admin-admins";
     }
 }

--- a/src/main/java/com/meztlitech/agrobitacora/service/AdminService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/AdminService.java
@@ -62,6 +62,11 @@ public class AdminService {
         return authenticationService.create(userDto);
     }
 
+    public UserResponse createAdmin(UserDto userDto) {
+        userDto.setRoleId(roleRepository.findByName("Admin").getId());
+        return authenticationService.create(userDto);
+    }
+
     public AdminCountsDto getCounts() {
         AdminCountsDto dto = new AdminCountsDto();
         dto.setProducers(userRepository.countByRoleName("Productor"));

--- a/src/main/resources/static/js/admin-admins.js
+++ b/src/main/resources/static/js/admin-admins.js
@@ -1,0 +1,14 @@
+App.registerEntity('adminadmins', {
+    url: '/api/admin/users?role=Admin',
+    buildRow: u => `<tr data-item="${App.enc(u)}"><td>${u.id}</td><td>${u.name}</td><td>${u.username}</td><td>${u.whatsapp || ''}</td><td>${u.maxCrops || ''}</td><td><button class='edit btn btn-sm btn-primary'>Editar</button> <button class='delete btn btn-sm btn-danger'>Eliminar</button></td></tr>`,
+    deleteUrl: id => `/api/admin/users/${id}`,
+    onEdit: data => {
+        const $form = $('#admin-admin-form');
+        if ($form.length) {
+            App.fillForm($form[0], data);
+            $form.attr('action', `/api/admin/users/${data.id}`);
+            $form[0].dataset.method = 'PUT';
+        }
+    },
+    afterLoad: App.loadAdminCounts
+});

--- a/src/main/resources/templates/admin-admins.html
+++ b/src/main/resources/templates/admin-admins.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments/head :: head('Administradores')}"></head>
+<body>
+<nav th:replace="~{fragments/nav :: nav}"></nav>
+<div class="container mt-4">
+  <h1 class="mb-4">
+    <a th:href="@{/admin}" class="btn btn-secondary btn-sm me-2">&larr;</a>
+      <span>Administradores</span>
+  </h1>
+  <div id="admin-counts" class="mb-4"></div>
+  <form id="admin-admin-form" class="api mb-4" method="post" action="/api/admin/admins">
+    <div class="row g-3">
+      <div class="col-md-4">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="name" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Usuario</label>
+        <input type="text" name="email" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Whatsapp</label>
+        <input type="text" name="whatsapp" class="form-control">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Contraseña</label>
+        <input type="password" name="password" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Límite cultivos</label>
+        <input type="number" name="maxCrops" class="form-control">
+      </div>
+    </div>
+      <button type="submit" class="btn btn-success mt-3">Crear</button>
+  </form>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Nombre</th>
+        <th>Usuario</th>
+        <th>Whatsapp</th>
+        <th>Límite</th>
+        <th>Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- user rows -->
+    </tbody>
+  </table>
+</div>
+<div th:replace="~{fragments/scripts :: base-scripts}"></div>
+<script th:src="@{/js/admin-admins.js}" defer></script>
+<footer th:replace="~{fragments/footer :: footer}"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -8,6 +8,7 @@
   <div class="list-group mb-4">
   <a class="list-group-item list-group-item-action" th:href="@{/admin/users}">Gestión de Usuarios</a>
   <a class="list-group-item list-group-item-action" th:href="@{/admin/engineers}">Alta de Ingenieros</a>
+  <a class="list-group-item list-group-item-action" th:href="@{/admin/admins}">Administradores</a>
   </div>
   <div id="admin-counts" class="mb-4"></div>
 </div>


### PR DESCRIPTION
## Summary
- add `/api/admin/admins` endpoint to create administrators
- support admin creation in the service
- add UI template and script for admin management
- link new page from admin menu
- restrict admin views to admin role

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6878131bc9308323b5e0abd1357f8f34