### PR TITLE
Enforce email-only login

### DIFF
--- a/src/main/java/com/meztlitech/agrobitacora/controller/AuthenticationController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/AuthenticationController.java
@@ -20,12 +20,18 @@ public class AuthenticationController {
     private final AuthenticationService authenticationService;
 
     @PostMapping("/signIn")
-    public ResponseEntity<UserResponse> signIn(@Valid @RequestBody SignInRequest request) {
-        return ResponseEntity.ok(authenticationService.signIn(request));
+    public ResponseEntity<?> signIn(@Valid @RequestBody SignInRequest request) {
+        UserResponse response = authenticationService.signIn(request);
+        if (response == null || response.getToken() == null) {
+            ActionStatusResponse error = new ActionStatusResponse();
+            error.setDescription("Credenciales inválidas");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+        }
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping(value = "/signIn", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public ResponseEntity<Void> signInForm(@Valid SignInRequest request) {
+    public ResponseEntity<?> signInForm(@Valid SignInRequest request) {
         UserResponse response = authenticationService.signIn(request);
         if (response != null && response.getToken() != null) {
             HttpHeaders headers = new HttpHeaders();
@@ -39,7 +45,9 @@ public class AuthenticationController {
             headers.add(HttpHeaders.LOCATION, target);
             return new ResponseEntity<>(headers, HttpStatus.FOUND);
         }
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        ActionStatusResponse error = new ActionStatusResponse();
+        error.setDescription("Credenciales inválidas");
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
     }
 
     @PostMapping("/signUp")

--- a/src/main/java/com/meztlitech/agrobitacora/controller/AuthenticationController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/AuthenticationController.java
@@ -70,6 +70,11 @@ public class AuthenticationController {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
     }
 
+    @PostMapping("/recoverPassword")
+    public ResponseEntity<ActionStatusResponse> recoverPassword(@Valid @RequestBody PasswordRecoveryRequest request) {
+        return ResponseEntity.ok(authenticationService.recoverPassword(request));
+    }
+
     @PostMapping("/verifySession")
     public ResponseEntity<UserResponse> verify(@RequestHeader(value = "Authorization") final String token) {
         return ResponseEntity.ok(authenticationService.verify(token));

--- a/src/main/java/com/meztlitech/agrobitacora/controller/AuthenticationController.java
+++ b/src/main/java/com/meztlitech/agrobitacora/controller/AuthenticationController.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/auth")
@@ -19,12 +20,12 @@ public class AuthenticationController {
     private final AuthenticationService authenticationService;
 
     @PostMapping("/signIn")
-    public ResponseEntity<UserResponse> signIn(@RequestBody SignInRequest request) {
+    public ResponseEntity<UserResponse> signIn(@Valid @RequestBody SignInRequest request) {
         return ResponseEntity.ok(authenticationService.signIn(request));
     }
 
     @PostMapping(value = "/signIn", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public ResponseEntity<Void> signInForm(SignInRequest request) {
+    public ResponseEntity<Void> signInForm(@Valid SignInRequest request) {
         UserResponse response = authenticationService.signIn(request);
         if (response != null && response.getToken() != null) {
             HttpHeaders headers = new HttpHeaders();
@@ -42,12 +43,12 @@ public class AuthenticationController {
     }
 
     @PostMapping("/signUp")
-    public ResponseEntity<UserResponse> signup(@RequestBody UserDto userDto) {
+    public ResponseEntity<UserResponse> signup(@Valid @RequestBody UserDto userDto) {
         return ResponseEntity.ok(authenticationService.create(userDto));
     }
 
     @PostMapping(value = "/signUp", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-    public ResponseEntity<Void> signupForm(UserDto userDto) {
+    public ResponseEntity<Void> signupForm(@Valid UserDto userDto) {
         UserResponse response = authenticationService.create(userDto);
         if (response != null && response.getToken() != null) {
             HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/meztlitech/agrobitacora/dto/PasswordRecoveryRequest.java
+++ b/src/main/java/com/meztlitech/agrobitacora/dto/PasswordRecoveryRequest.java
@@ -1,0 +1,24 @@
+package com.meztlitech.agrobitacora.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordRecoveryRequest {
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String whatsapp;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/meztlitech/agrobitacora/dto/SignInRequest.java
+++ b/src/main/java/com/meztlitech/agrobitacora/dto/SignInRequest.java
@@ -4,14 +4,20 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class SignInRequest {
-    // login can be either email or whatsapp number
+    // login must be a valid email
+    @NotBlank
+    @Email
     private String login;
+
+    @NotBlank
     private String password;
     private boolean remember;
 }

--- a/src/main/java/com/meztlitech/agrobitacora/dto/UserDto.java
+++ b/src/main/java/com/meztlitech/agrobitacora/dto/UserDto.java
@@ -2,6 +2,8 @@ package com.meztlitech.agrobitacora.dto;
 
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 @Data
 @RequiredArgsConstructor
@@ -9,7 +11,11 @@ public class UserDto {
 
     private String name;
     private Long roleId;
+    @NotBlank
+    @Email
     private String email;
+
+    @NotBlank
     private String password;
     private String whatsapp;
     private Integer maxCrops;

--- a/src/main/java/com/meztlitech/agrobitacora/repository/UserRepository.java
+++ b/src/main/java/com/meztlitech/agrobitacora/repository/UserRepository.java
@@ -13,6 +13,12 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
     @Query("FROM UserEntity u WHERE u.userName = :username")
     Optional<UserEntity> findByUserName(String username);
 
+    boolean existsByUserName(String userName);
+
+    Optional<UserEntity> findByWhatsapp(String whatsapp);
+
+    boolean existsByWhatsapp(String whatsapp);
+
     @Query("FROM UserEntity u WHERE u.userName = :login OR u.whatsapp = :login")
     Optional<UserEntity> findByUserNameOrWhatsapp(String login);
 

--- a/src/main/java/com/meztlitech/agrobitacora/service/AuthenticationService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/AuthenticationService.java
@@ -56,6 +56,19 @@ public class AuthenticationService {
         }
     }
 
+    private void validateUnique(String email, String whatsapp, Long userId) {
+        if (StringUtils.isNotBlank(email)) {
+            userRepository.findByUserName(email)
+                    .filter(u -> userId == null || !u.getId().equals(userId))
+                    .ifPresent(u -> { throw new IllegalArgumentException("Correo ya registrado"); });
+        }
+        if (StringUtils.isNotBlank(whatsapp)) {
+            userRepository.findByWhatsapp(whatsapp)
+                    .filter(u -> userId == null || !u.getId().equals(userId))
+                    .ifPresent(u -> { throw new IllegalArgumentException("Whatsapp ya registrado"); });
+        }
+    }
+
     public UserResponse signIn(SignInRequest request) {
         try {
             UserEntity user = userRepository.findByUserName(request.getLogin())
@@ -96,6 +109,7 @@ public class AuthenticationService {
             user.setWhatsapp(request.getWhatsapp());
             user.setMaxCrops(request.getMaxCrops());
             validateContactInfo(user.getUserName(), user.getWhatsapp());
+            validateUnique(user.getUserName(), user.getWhatsapp(), null);
             userRepository.save(user);
 
             return this.signIn(new SignInRequest(request.getEmail(), request.getPassword(), false));
@@ -167,6 +181,7 @@ public class AuthenticationService {
                 user.setMaxCrops(userDto.getMaxCrops());
             }
             validateContactInfo(user.getUserName(), user.getWhatsapp());
+            validateUnique(user.getUserName(), user.getWhatsapp(), user.getId());
             userRepository.save(user);
             actionStatusResponse.setId(user.getId());
             actionStatusResponse.setStatus(HttpStatus.OK);

--- a/src/main/java/com/meztlitech/agrobitacora/service/AuthenticationService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/AuthenticationService.java
@@ -42,7 +42,7 @@ public class AuthenticationService {
 
     public UserResponse signIn(SignInRequest request) {
         try {
-            UserEntity user = userRepository.findByUserNameOrWhatsapp(request.getLogin())
+            UserEntity user = userRepository.findByUserName(request.getLogin())
                     .orElseThrow(() -> new IllegalArgumentException("Invalid credentials."));
 
             authenticationManager.authenticate(

--- a/src/main/java/com/meztlitech/agrobitacora/service/AuthenticationService.java
+++ b/src/main/java/com/meztlitech/agrobitacora/service/AuthenticationService.java
@@ -5,6 +5,7 @@ import com.meztlitech.agrobitacora.dto.JwtAuthenticationResponse;
 import com.meztlitech.agrobitacora.dto.SignInRequest;
 import com.meztlitech.agrobitacora.dto.UserDto;
 import com.meztlitech.agrobitacora.dto.UserResponse;
+import com.meztlitech.agrobitacora.dto.PasswordRecoveryRequest;
 import com.meztlitech.agrobitacora.entity.UserEntity;
 import com.meztlitech.agrobitacora.repository.RoleRepository;
 import com.meztlitech.agrobitacora.repository.UserRepository;
@@ -192,6 +193,28 @@ public class AuthenticationService {
             actionStatusResponse.setErrors(errors);
         }
         return actionStatusResponse;
+    }
+
+    public ActionStatusResponse recoverPassword(PasswordRecoveryRequest request) {
+        ActionStatusResponse resp = new ActionStatusResponse();
+        try {
+            validateContactInfo(request.getEmail(), request.getWhatsapp());
+            UserEntity user = userRepository.findByUserName(request.getEmail())
+                    .orElseThrow(() -> new IllegalArgumentException("Datos inválidos"));
+            if (!StringUtils.equals(user.getWhatsapp(), request.getWhatsapp())) {
+                throw new IllegalArgumentException("Datos inválidos");
+            }
+            user.setPassword(passwordEncoder.encode(request.getPassword()));
+            userRepository.save(user);
+            resp.setId(user.getId());
+            resp.setStatus(HttpStatus.OK);
+            resp.setDescription("Actualizado correctamente");
+        } catch (Exception ex) {
+            Map<HttpStatus, String> errors = new HashMap<>();
+            errors.put(HttpStatus.BAD_REQUEST, ex.getMessage());
+            resp.setErrors(errors);
+        }
+        return resp;
     }
 
     public UserResponse verify(String token) {

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -609,7 +609,9 @@
             App.notify((info && (info.description || info.message)) || 'Error', 'danger');
             if (res.status === 401) {
                 App.clearAuth();
-                location.href = '/auth';
+                if (this.id !== 'sign-in-form') {
+                    location.href = '/auth';
+                }
             }
         }
         });

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -586,6 +586,10 @@
                         App.notify('Credenciales inválidas', 'danger');
                     }
                     return;
+                } else if (this.id === 'recover-form') {
+                    App.notify('Contraseña actualizada', 'success');
+                    this.reset();
+                    return;
                 }
                 App.notify('Guardado correctamente', 'success');
                 App.loadData(page);

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -7,6 +7,9 @@
     <a class="navbar-brand" th:href="@{/}">Agro Bitácora</a>
   </div>
 </nav>
+<div aria-live="polite" aria-atomic="true" class="position-fixed top-0 end-0 p-3" style="z-index: 11">
+  <div id="toast-container"></div>
+</div>
 <div class="container mt-4">
   <h1 class="mb-4">
   <span>Gestión de Autenticación</span>

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -16,12 +16,12 @@
         <h2>Iniciar sesión</h2>
       <form id="sign-in-form" class="api" method="post" action="/auth/signIn">
         <div class="mb-3">
-          <label class="form-label">Correo o Whatsapp</label>
-          <input type="text" name="login" class="form-control">
+          <label class="form-label">Correo</label>
+          <input type="email" name="login" class="form-control" required>
         </div>
         <div class="mb-3">
           <label class="form-label">Contraseña</label>
-          <input type="password" name="password" class="form-control">
+          <input type="password" name="password" class="form-control" required>
         </div>
         <div class="mb-3 form-check">
           <input type="checkbox" class="form-check-input" id="remember" name="remember">
@@ -50,16 +50,16 @@
             <input type="text" name="name" class="form-control">
           </div>
           <div class="mb-3">
-            <label class="form-label">Usuario</label>
-            <input type="text" name="email" class="form-control">
+          <label class="form-label">Correo</label>
+          <input type="email" name="email" class="form-control" required>
           </div>
           <div class="mb-3">
             <label class="form-label">Whatsapp</label>
             <input type="text" name="whatsapp" class="form-control">
           </div>
           <div class="mb-3">
-            <label class="form-label">Contraseña</label>
-            <input type="password" name="password" class="form-control">
+          <label class="form-label">Contraseña</label>
+          <input type="password" name="password" class="form-control" required>
           </div>
             <button type="submit" class="btn btn-success">Registrar</button>
         </form>

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -34,6 +34,9 @@
             <button type="submit" class="btn btn-primary">Ingresar</button>
             <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#signupModal">Registrarse</button>
         </div>
+        <div class="mt-2 text-end">
+            <button type="button" class="btn btn-link" data-bs-toggle="modal" data-bs-target="#recoverModal">¿Olvidaste tu contraseña?</button>
+        </div>
       </form>
     </div>
   </div>
@@ -65,6 +68,35 @@
           <input type="password" name="password" class="form-control" required>
           </div>
             <button type="submit" class="btn btn-success">Registrar</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Recover Password Modal -->
+<div class="modal fade" id="recoverModal" tabindex="-1" aria-labelledby="recoverModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+          <h5 class="modal-title" id="recoverModalLabel">Recuperar Contraseña</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="recover-form" class="api" method="post" action="/auth/recoverPassword">
+          <div class="mb-3">
+            <label class="form-label">Correo</label>
+            <input type="email" name="email" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Whatsapp</label>
+            <input type="text" name="whatsapp" class="form-control" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">Nueva contraseña</label>
+            <input type="password" name="password" class="form-control" required>
+          </div>
+            <button type="submit" class="btn btn-primary">Actualizar</button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- require email format for sign in and sign up
- validate credentials with Jakarta Validation
- adjust authentication to search user by email only
- update login & registration forms

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687aa438dd8c83239260b1a2691b8c7d