### PR TITLE
Open creation forms in modals

### DIFF
--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -17,7 +17,7 @@
   <div class="row justify-content-center">
     <div class="col-md-6">
         <h2>Iniciar sesión</h2>
-      <form id="sign-in-form" class="api" method="post" action="/auth/signIn">
+      <form id="sign-in-form" class="api" data-no-modal method="post" action="/auth/signIn">
         <div class="mb-3">
           <label class="form-label">Correo</label>
           <input type="email" name="login" class="form-control" required>

--- a/src/main/resources/templates/balance.html
+++ b/src/main/resources/templates/balance.html
@@ -8,7 +8,7 @@
     <a th:href="@{/}" class="btn btn-secondary btn-sm me-2">&larr;</a>
     Balance general
   </h1>
-  <form id="balance-form" class="row g-3 mb-3">
+  <form id="balance-form" class="row g-3 mb-3" data-no-modal>
     <div class="col-md-4">
       <label class="form-label">Desde</label>
       <input type="date" name="start" class="form-control" required>

--- a/src/main/resources/templates/bill.html
+++ b/src/main/resources/templates/bill.html
@@ -53,7 +53,7 @@
   </table>
 
   <h2 class="mt-5">Resumen de gastos</h2>
-  <form id="bill-summary-form" class="row g-3 mb-3">
+  <form id="bill-summary-form" class="row g-3 mb-3" data-no-modal>
     <div class="col-md-4">
       <label class="form-label">Desde</label>
       <input type="date" name="start" class="form-control" required>

--- a/src/main/resources/templates/production.html
+++ b/src/main/resources/templates/production.html
@@ -29,7 +29,7 @@
   </form>
 
   <h2 class="mt-5">Corte de ventas por fecha</h2>
-  <form id="summary-form" class="row g-3 mb-3">
+  <form id="summary-form" class="row g-3 mb-3" data-no-modal>
     <div class="col-md-4">
       <label class="form-label">Fecha</label>
       <input type="date" name="date" class="form-control" required>


### PR DESCRIPTION
## Summary
- Wrap API forms in Bootstrap modals and auto-generate "Crear" buttons
- Open modal when editing an item and close after successful save
- Exclude authentication and report forms from modal handling via `data-no-modal`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab96112a788323920915e145379f81